### PR TITLE
local health check should be local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ VITE_AUTH0_AUDIENCE="auth0_audience"
 VITE_AUTH0_REDIRECT_URI="auth0_redirect_uri"
 VITE_GRPC_BASE_URL="localhost:3000"
 VITE_AMPLITUDE_API_KEY="amplitude_api_key"
+VITE_LOCAL_SERVER_PORT=3000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the electron-react-app (ERA) are listed here.
 
 <br>
 
+### v0.2.2
+
+- check localhost, not grpc_base_url
+
 ### v0.2.1
 
 - disable localhost sign in option if a local server is not running

--- a/lib/window/ipcEvents.ts
+++ b/lib/window/ipcEvents.ts
@@ -302,9 +302,12 @@ export function registerIPC() {
   // Server health check
   handleIPC('check-server-health', async () => {
     try {
-      const response = await fetch(import.meta.env.VITE_GRPC_BASE_URL, {
-        method: 'GET',
-      })
+      const response = await fetch(
+        `http://localhost:${import.meta.env.VITE_LOCAL_SERVER_PORT}`,
+        {
+          method: 'GET',
+        },
+      )
 
       if (response.ok) {
         const text = await response.text()

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_GRPC_BASE_URL: string
   readonly VITE_AMPLITUDE_API_KEY: string
   readonly VITE_UPDATER_BUCKET: string
+  readonly VITE_LOCAL_SERVER_PORT?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
had a mistake where I used the VITE_GRPC_BASE_URL, which for production is set for our production server. The health check for local should always check localhost