### PR TITLE
Adding CDN for edge caching + infra cleaup 

### DIFF
--- a/server/infra/.gitignore
+++ b/server/infra/.gitignore
@@ -2,6 +2,8 @@
 !jest.config.js
 *.d.ts
 node_modules
+yarn.lock
+bun.lockb
 
 # CDK asset staging directory
 .cdk.staging


### PR DESCRIPTION
Adding CDN 

Due to the self-referential nature of the ci stack I already deployed these changes from my local to test it out. This would just be for tracking 

Added the yarn.lock and bun.lock ignores so that we unify on npm for the infra folder (which is necessary to not confuse the ci with multiple lock files) 