### PR TITLE
Add TikTok, Instagram, and Discord to referral sources

### DIFF
--- a/app/components/welcome/contents/ReferralContent.tsx
+++ b/app/components/welcome/contents/ReferralContent.tsx
@@ -11,6 +11,9 @@ import { useAuthStore } from '@/app/store/useAuthStore'
 
 const sources = [
   'Twitter',
+  'TikTok',
+  'Instagram',
+  'Discord',
   'YouTube',
   'Reddit',
   'Friend',


### PR DESCRIPTION
Added three popular social media platforms to the referral source dropdown in the onboarding flow to better track where new users are discovering Ito.