### PR TITLE
Update X (Twitter) link to @ItoAssists

### DIFF
--- a/lib/constants/external-links.ts
+++ b/lib/constants/external-links.ts
@@ -1,7 +1,7 @@
 export const EXTERNAL_LINKS = {
   DISCORD: 'https://discord.gg/PME7NH38sn',
   TEAM_CALL: 'https://link.heyito.ai/calendly',
-  X_TWITTER: 'https://x.com/MachinaSpeaks',
+  X_TWITTER: 'https://x.com/ItoAssists',
   GITHUB: 'https://github.com/heyito/ito',
   WEBSITE: 'https://www.heyito.ai/',
   PRIVACY_POLICY: 'https://www.heyito.ai/privacy',


### PR DESCRIPTION
Changed the X/Twitter link in the about page from @MachinaSpeaks to @ItoAssists