### PR TITLE
Fixing llm prompt passing in headers 

### DIFF
--- a/app/components/home/contents/settings/AdvancedSettingsContent.tsx
+++ b/app/components/home/contents/settings/AdvancedSettingsContent.tsx
@@ -17,7 +17,7 @@ type LlmSettingConfig = {
 const modelProviderLengthLimit = 30
 const floatLengthLimit = 4
 const asrPromptLengthLimit = 100
-const transcriptionPromptLengthLimit = 500
+const llmPromptLenghtLimit = 1500
 
 const llmSettingsConfig: LlmSettingConfig[] = [
   {
@@ -73,7 +73,7 @@ const llmSettingsConfig: LlmSettingConfig[] = [
     placeholder: 'Enter custom transcription prompt',
     description:
       'A custom prompt to guide the transcription process for better accuracy. (Leave empty for default)',
-    maxLength: transcriptionPromptLengthLimit,
+    maxLength: llmPromptLenghtLimit,
     resize: true,
   },
   {
@@ -82,7 +82,7 @@ const llmSettingsConfig: LlmSettingConfig[] = [
     placeholder: 'Enter custom editing prompt',
     description:
       'A custom prompt to guide the editing process for improved text quality. (Leave empty for default)',
-    maxLength: transcriptionPromptLengthLimit,
+    maxLength: llmPromptLenghtLimit,
     resize: true,
   },
   {

--- a/lib/clients/grpcClient.ts
+++ b/lib/clients/grpcClient.ts
@@ -95,6 +95,13 @@ class GrpcClient {
         headers.set('app-name', windowContext.appName)
       }
 
+      function flattenHeaderValue(value: string) {
+        return value
+          .replace(/[\r\n]+/g, ' ')
+          .replace(/\s{2,}/g, ' ')
+          .trim()
+      }
+
       // Add ASR model from advanced settings
       const advancedSettings = getAdvancedSettings()
       console.log(
@@ -103,7 +110,10 @@ class GrpcClient {
       )
       headers.set('asr-model', advancedSettings.llm.asrModel)
       headers.set('asr-provider', advancedSettings.llm.asrProvider)
-      headers.set('asr-prompt', advancedSettings.llm.asrPrompt)
+      headers.set(
+        'asr-prompt',
+        flattenHeaderValue(advancedSettings.llm.asrPrompt),
+      )
       headers.set('llm-provider', advancedSettings.llm.llmProvider)
       headers.set('llm-model', advancedSettings.llm.llmModel)
       headers.set(
@@ -112,9 +122,12 @@ class GrpcClient {
       )
       headers.set(
         'transcription-prompt',
-        advancedSettings.llm.transcriptionPrompt,
+        flattenHeaderValue(advancedSettings.llm.transcriptionPrompt),
       )
-      headers.set('editing-prompt', advancedSettings.llm.editingPrompt)
+      headers.set(
+        'editing-prompt',
+        flattenHeaderValue(advancedSettings.llm.editingPrompt),
+      )
       headers.set(
         'no-speech-threshold',
         advancedSettings.llm.noSpeechThreshold.toString(),

--- a/lib/constants/generated-defaults.ts
+++ b/lib/constants/generated-defaults.ts
@@ -16,32 +16,32 @@ export const DEFAULT_ADVANCED_SETTINGS = {
   llmTemperature: 0.1,
 
   // Prompt settings
-  transcriptionPrompt: `You are a real-time Transcript Polisher assistant. Your job is to take a raw speech transcript—complete with hesitations (“uh,” “um”), false starts, repetitions, and filler—and produce a concise, polished version suitable for pasting directly into the user's active document (email, report, chat, etc.).
+  transcriptionPrompt: `You are a real-time Transcript Polisher assistant. Your job is to take a raw speech transcript-complete with hesitations ("uh," "um"), false starts, repetitions, and filler-and produce a concise, polished version suitable for pasting directly into the user's active document (email, report, chat, etc.).
 
-— Keep the user's meaning and tone intact: don't introduce ideas or change intent.
-— Remove disfluencies: delete “uh,” “um,” “you know,” repeated words, and false starts.
-— Resolve corrections smoothly: when the speaker self-corrects (“let's do next week… no, next month”), choose the final phrasing.
-— Preserve natural phrasing: maintain contractions and informal tone if present, unless clarity demands adjustment.
-— Maintain accuracy: do not invent or omit key details like dates, names, or numbers.
-— Produce clean prose: use complSmiley faceete sentences, correct punctuation, and paragraph breaks only where needed for readability.
-— Operate within a single reply: output only the cleaned text—no commentary, meta-notes, or apologies.
+- Keep the user's meaning and tone intact: don't introduce ideas or change intent.
+- Remove disfluencies: delete "uh," "um," "you know," repeated words, and false starts.
+- Resolve corrections smoothly: when the speaker self-corrects ("let's do next week... no, next month"), choose the final phrasing.
+- Preserve natural phrasing: maintain contractions and informal tone if present, unless clarity demands adjustment.
+- Maintain accuracy: do not invent or omit key details like dates, names, or numbers.
+- Produce clean prose: use complSmiley faceete sentences, correct punctuation, and paragraph breaks only where needed for readability.
+- Operate within a single reply: output only the cleaned text-no commentary, meta-notes, or apologies.
 
 Example
 Raw transcript:
-“Uhhh, so, I was thinking… maybe we could—uh—shoot for Thursday morning? No, actually, let's aim for the first week of May.”
+"Uhhh, so, I was thinking... maybe we could-uh-shoot for Thursday morning? No, actually, let's aim for the first week of May."
 
 Cleaned output:
-“Let's schedule the meeting for the first week of May.”
+"Let's schedule the meeting for the first week of May."
 
 When you receive a transcript, immediately return the polished version following these rules.
 `,
-  editingPrompt: ` You are a Command-Interpreter assistant. Your job is to take a raw speech transcript—complete with hesitations, false starts, “umm”s and self-corrections—and treat it as the user issuing a high-level instruction. Instead of merely polishing their words, you must:
-    1.	Extract the intent: identify the action the user is asking for (e.g. “write me a GitHub issue,” “draft a sorry-I-missed-our-meeting email,” “produce a summary of X,” etc.).
-    2.	Ignore disfluencies: strip out “uh,” “um,” false starts and filler so you see only the core command.
+  editingPrompt: ` You are a Command-Interpreter assistant. Your job is to take a raw speech transcript-complete with hesitations, false starts, "umm"s and self-corrections-and treat it as the user issuing a high-level instruction. Instead of merely polishing their words, you must:
+    1.	Extract the intent: identify the action the user is asking for (e.g. "write me a GitHub issue," "draft a sorry-I-missed-our-meeting email," "produce a summary of X," etc.).
+    2.	Ignore disfluencies: strip out "uh," "um," false starts and filler so you see only the core command.
     3.	Map to a template: choose an appropriate standard format (GitHub issue markdown template, professional email, bullet-point agenda, etc.) that matches the intent.
     4.	Generate the deliverable: produce a fully-formed document in that format, filling in placeholders sensibly from any details in the transcript.
-    5.	Do not add new intent: if the transcript doesn't specify something (e.g. title, recipients, date), use reasonable defaults (e.g. “Untitled Issue,” “To: [Recipient]”) or prompt the user for the missing piece.
-    6.	Produce only the final document: no commentary, apologies, or side-notes—just the completed issue/email/summary/etc.
+    5.	Do not add new intent: if the transcript doesn't specify something (e.g. title, recipients, date), use reasonable defaults (e.g. "Untitled Issue," "To: [Recipient]") or prompt the user for the missing piece.
+    6.	Produce only the final document: no commentary, apologies, or side-notes-just the completed issue/email/summary/etc.
     7. Your response MUST contain ONLY the resultant text. DO NOT include:
       - Any markers like [START/END CURRENT NOTES CONTENT]
       - Any explanations, apologies, or additional text

--- a/server/src/constants/generated-defaults.ts
+++ b/server/src/constants/generated-defaults.ts
@@ -16,32 +16,32 @@ export const DEFAULT_ADVANCED_SETTINGS = {
   llmTemperature: 0.1,
 
   // Prompt settings
-  transcriptionPrompt: `You are a real-time Transcript Polisher assistant. Your job is to take a raw speech transcript—complete with hesitations (“uh,” “um”), false starts, repetitions, and filler—and produce a concise, polished version suitable for pasting directly into the user's active document (email, report, chat, etc.).
+  transcriptionPrompt: `You are a real-time Transcript Polisher assistant. Your job is to take a raw speech transcript-complete with hesitations ("uh," "um"), false starts, repetitions, and filler-and produce a concise, polished version suitable for pasting directly into the user's active document (email, report, chat, etc.).
 
-— Keep the user's meaning and tone intact: don't introduce ideas or change intent.
-— Remove disfluencies: delete “uh,” “um,” “you know,” repeated words, and false starts.
-— Resolve corrections smoothly: when the speaker self-corrects (“let's do next week… no, next month”), choose the final phrasing.
-— Preserve natural phrasing: maintain contractions and informal tone if present, unless clarity demands adjustment.
-— Maintain accuracy: do not invent or omit key details like dates, names, or numbers.
-— Produce clean prose: use complSmiley faceete sentences, correct punctuation, and paragraph breaks only where needed for readability.
-— Operate within a single reply: output only the cleaned text—no commentary, meta-notes, or apologies.
+- Keep the user's meaning and tone intact: don't introduce ideas or change intent.
+- Remove disfluencies: delete "uh," "um," "you know," repeated words, and false starts.
+- Resolve corrections smoothly: when the speaker self-corrects ("let's do next week... no, next month"), choose the final phrasing.
+- Preserve natural phrasing: maintain contractions and informal tone if present, unless clarity demands adjustment.
+- Maintain accuracy: do not invent or omit key details like dates, names, or numbers.
+- Produce clean prose: use complSmiley faceete sentences, correct punctuation, and paragraph breaks only where needed for readability.
+- Operate within a single reply: output only the cleaned text-no commentary, meta-notes, or apologies.
 
 Example
 Raw transcript:
-“Uhhh, so, I was thinking… maybe we could—uh—shoot for Thursday morning? No, actually, let's aim for the first week of May.”
+"Uhhh, so, I was thinking... maybe we could-uh-shoot for Thursday morning? No, actually, let's aim for the first week of May."
 
 Cleaned output:
-“Let's schedule the meeting for the first week of May.”
+"Let's schedule the meeting for the first week of May."
 
 When you receive a transcript, immediately return the polished version following these rules.
 `,
-  editingPrompt: ` You are a Command-Interpreter assistant. Your job is to take a raw speech transcript—complete with hesitations, false starts, “umm”s and self-corrections—and treat it as the user issuing a high-level instruction. Instead of merely polishing their words, you must:
-    1.	Extract the intent: identify the action the user is asking for (e.g. “write me a GitHub issue,” “draft a sorry-I-missed-our-meeting email,” “produce a summary of X,” etc.).
-    2.	Ignore disfluencies: strip out “uh,” “um,” false starts and filler so you see only the core command.
+  editingPrompt: ` You are a Command-Interpreter assistant. Your job is to take a raw speech transcript-complete with hesitations, false starts, "umm"s and self-corrections-and treat it as the user issuing a high-level instruction. Instead of merely polishing their words, you must:
+    1.	Extract the intent: identify the action the user is asking for (e.g. "write me a GitHub issue," "draft a sorry-I-missed-our-meeting email," "produce a summary of X," etc.).
+    2.	Ignore disfluencies: strip out "uh," "um," false starts and filler so you see only the core command.
     3.	Map to a template: choose an appropriate standard format (GitHub issue markdown template, professional email, bullet-point agenda, etc.) that matches the intent.
     4.	Generate the deliverable: produce a fully-formed document in that format, filling in placeholders sensibly from any details in the transcript.
-    5.	Do not add new intent: if the transcript doesn't specify something (e.g. title, recipients, date), use reasonable defaults (e.g. “Untitled Issue,” “To: [Recipient]”) or prompt the user for the missing piece.
-    6.	Produce only the final document: no commentary, apologies, or side-notes—just the completed issue/email/summary/etc.
+    5.	Do not add new intent: if the transcript doesn't specify something (e.g. title, recipients, date), use reasonable defaults (e.g. "Untitled Issue," "To: [Recipient]") or prompt the user for the missing piece.
+    6.	Produce only the final document: no commentary, apologies, or side-notes-just the completed issue/email/summary/etc.
     7. Your response MUST contain ONLY the resultant text. DO NOT include:
       - Any markers like [START/END CURRENT NOTES CONTENT]
       - Any explanations, apologies, or additional text

--- a/server/src/validation/schemas.ts
+++ b/server/src/validation/schemas.ts
@@ -39,7 +39,10 @@ export const LLMTemperatureSchema = z
   .min(0, 'Temperature must be at least 0')
   .max(2, 'Temperature cannot exceed 2')
 
-export const LlmPromptSchema = z.string().trim().max(500, 'LLM prompt too long')
+export const LlmPromptSchema = z
+  .string()
+  .trim()
+  .max(1500, 'LLM prompt too long')
 
 export const NoSpeechThresholdSchema = z
   .number()

--- a/shared-constants.js
+++ b/shared-constants.js
@@ -15,32 +15,32 @@ const DEFAULT_ADVANCED_SETTINGS = {
   llmTemperature: 0.1,
 
   // Prompt settings
-  transcriptionPrompt: `You are a real-time Transcript Polisher assistant. Your job is to take a raw speech transcript—complete with hesitations (“uh,” “um”), false starts, repetitions, and filler—and produce a concise, polished version suitable for pasting directly into the user's active document (email, report, chat, etc.).
+  transcriptionPrompt: `You are a real-time Transcript Polisher assistant. Your job is to take a raw speech transcript-complete with hesitations ("uh," "um"), false starts, repetitions, and filler-and produce a concise, polished version suitable for pasting directly into the user's active document (email, report, chat, etc.).
 
-— Keep the user's meaning and tone intact: don't introduce ideas or change intent.
-— Remove disfluencies: delete “uh,” “um,” “you know,” repeated words, and false starts.
-— Resolve corrections smoothly: when the speaker self-corrects (“let's do next week… no, next month”), choose the final phrasing.
-— Preserve natural phrasing: maintain contractions and informal tone if present, unless clarity demands adjustment.
-— Maintain accuracy: do not invent or omit key details like dates, names, or numbers.
-— Produce clean prose: use complSmiley faceete sentences, correct punctuation, and paragraph breaks only where needed for readability.
-— Operate within a single reply: output only the cleaned text—no commentary, meta-notes, or apologies.
+- Keep the user's meaning and tone intact: don't introduce ideas or change intent.
+- Remove disfluencies: delete "uh," "um," "you know," repeated words, and false starts.
+- Resolve corrections smoothly: when the speaker self-corrects ("let's do next week... no, next month"), choose the final phrasing.
+- Preserve natural phrasing: maintain contractions and informal tone if present, unless clarity demands adjustment.
+- Maintain accuracy: do not invent or omit key details like dates, names, or numbers.
+- Produce clean prose: use complSmiley faceete sentences, correct punctuation, and paragraph breaks only where needed for readability.
+- Operate within a single reply: output only the cleaned text-no commentary, meta-notes, or apologies.
 
 Example
 Raw transcript:
-“Uhhh, so, I was thinking… maybe we could—uh—shoot for Thursday morning? No, actually, let's aim for the first week of May.”
+"Uhhh, so, I was thinking... maybe we could-uh-shoot for Thursday morning? No, actually, let's aim for the first week of May."
 
 Cleaned output:
-“Let's schedule the meeting for the first week of May.”
+"Let's schedule the meeting for the first week of May."
 
 When you receive a transcript, immediately return the polished version following these rules.
 `,
-  editingPrompt: ` You are a Command-Interpreter assistant. Your job is to take a raw speech transcript—complete with hesitations, false starts, “umm”s and self-corrections—and treat it as the user issuing a high-level instruction. Instead of merely polishing their words, you must:
-    1.	Extract the intent: identify the action the user is asking for (e.g. “write me a GitHub issue,” “draft a sorry-I-missed-our-meeting email,” “produce a summary of X,” etc.).
-    2.	Ignore disfluencies: strip out “uh,” “um,” false starts and filler so you see only the core command.
+  editingPrompt: ` You are a Command-Interpreter assistant. Your job is to take a raw speech transcript-complete with hesitations, false starts, "umm"s and self-corrections-and treat it as the user issuing a high-level instruction. Instead of merely polishing their words, you must:
+    1.	Extract the intent: identify the action the user is asking for (e.g. "write me a GitHub issue," "draft a sorry-I-missed-our-meeting email," "produce a summary of X," etc.).
+    2.	Ignore disfluencies: strip out "uh," "um," false starts and filler so you see only the core command.
     3.	Map to a template: choose an appropriate standard format (GitHub issue markdown template, professional email, bullet-point agenda, etc.) that matches the intent.
     4.	Generate the deliverable: produce a fully-formed document in that format, filling in placeholders sensibly from any details in the transcript.
-    5.	Do not add new intent: if the transcript doesn't specify something (e.g. title, recipients, date), use reasonable defaults (e.g. “Untitled Issue,” “To: [Recipient]”) or prompt the user for the missing piece.
-    6.	Produce only the final document: no commentary, apologies, or side-notes—just the completed issue/email/summary/etc.
+    5.	Do not add new intent: if the transcript doesn't specify something (e.g. title, recipients, date), use reasonable defaults (e.g. "Untitled Issue," "To: [Recipient]") or prompt the user for the missing piece.
+    6.	Produce only the final document: no commentary, apologies, or side-notes-just the completed issue/email/summary/etc.
     7. Your response MUST contain ONLY the resultant text. DO NOT include:
       - Any markers like [START/END CURRENT NOTES CONTENT]
       - Any explanations, apologies, or additional text


### PR DESCRIPTION
This fix addresses issue on passing the llm prompts thru the headers 

Previous there were ascii characters that aren't serializable for header protocols i.e. emdashes, curly quotes

Additionally since we use a template sting it has newlines which are also not allowed. Added flattening on the prompts for the headers. 
