### PR TITLE
Hide the detailed examples button and change the default no Speech value

### DIFF
--- a/app/components/welcome/contents/IntroducingIntelligentModeContent.tsx
+++ b/app/components/welcome/contents/IntroducingIntelligentModeContent.tsx
@@ -57,22 +57,11 @@ export default function IntroducingIntelligentMode() {
               >
                 <ArrowRight className="h-5 w-5 shrink-0 text-black" />
                 {step}
-              </div>
-            ))}
-            <Button
-              variant="outline"
-              size="sm"
-              type="button"
-              onClick={() => {
-                /** TODO: New screens for detailed examples */
-              }}
-              className={'w-fit p-4 mt-6'}
-            >
-              {'Detailed Examples'}
-            </Button>
+            </div>
+            ))}}
             <Tip
               tipText="You can also trigger Intelligent Mode by saying 'Hey Ito' when using the regular dictation hotkey."
-              className="mt-3"
+              className="mt-6"
             />
           </div>
 

--- a/lib/constants/generated-defaults.ts
+++ b/lib/constants/generated-defaults.ts
@@ -49,6 +49,6 @@ When you receive a transcript, immediately return the polished version following
   `,
 
   // Audio quality thresholds
-  noSpeechThreshold: 0.35,
+  noSpeechThreshold: 0.6,
   lowQualityThreshold: -0.55,
 } as const

--- a/server/src/constants/generated-defaults.ts
+++ b/server/src/constants/generated-defaults.ts
@@ -49,6 +49,6 @@ When you receive a transcript, immediately return the polished version following
   `,
 
   // Audio quality thresholds
-  noSpeechThreshold: 0.35,
+  noSpeechThreshold: 0.6,
   lowQualityThreshold: -0.55,
 } as const

--- a/shared-constants.js
+++ b/shared-constants.js
@@ -48,7 +48,7 @@ When you receive a transcript, immediately return the polished version following
   `,
 
   // Audio quality thresholds
-  noSpeechThreshold: 0.35,
+  noSpeechThreshold: 0.60,
   lowQualityThreshold: -0.55,
 }
 


### PR DESCRIPTION
Hid the detailed example button from onboarding screen as well as change the default no speech value variable from 0.35 to 0.6 to best suit our specific use case.