### PR TITLE
Remove Detailed Examples button and update no speech threshold

### DIFF
--- a/app/components/welcome/contents/IntroducingIntelligentModeContent.tsx
+++ b/app/components/welcome/contents/IntroducingIntelligentModeContent.tsx
@@ -59,17 +59,6 @@ export default function IntroducingIntelligentMode() {
                 {step}
               </div>
             ))}
-            <Button
-              variant="outline"
-              size="sm"
-              type="button"
-              onClick={() => {
-                /** TODO: New screens for detailed examples */
-              }}
-              className={'w-fit p-4 mt-6'}
-            >
-              {'Detailed Examples'}
-            </Button>
             <Tip
               tipText="You can also trigger Intelligent Mode by saying 'Hey Ito' when using the regular dictation hotkey."
               className="mt-3"

--- a/lib/constants/generated-defaults.ts
+++ b/lib/constants/generated-defaults.ts
@@ -49,6 +49,6 @@ When you receive a transcript, immediately return the polished version following
   `,
 
   // Audio quality thresholds
-  noSpeechThreshold: 0.35,
+  noSpeechThreshold: 0.6,
   lowQualityThreshold: -0.55,
 } as const

--- a/server/src/constants/generated-defaults.ts
+++ b/server/src/constants/generated-defaults.ts
@@ -49,6 +49,6 @@ When you receive a transcript, immediately return the polished version following
   `,
 
   // Audio quality thresholds
-  noSpeechThreshold: 0.35,
+  noSpeechThreshold: 0.6,
   lowQualityThreshold: -0.55,
 } as const

--- a/shared-constants.js
+++ b/shared-constants.js
@@ -48,7 +48,7 @@ When you receive a transcript, immediately return the polished version following
   `,
 
   // Audio quality thresholds
-  noSpeechThreshold: 0.35,
+  noSpeechThreshold: 0.60,
   lowQualityThreshold: -0.55,
 }
 

--- a/shared-constants.js
+++ b/shared-constants.js
@@ -48,7 +48,7 @@ When you receive a transcript, immediately return the polished version following
   `,
 
   // Audio quality thresholds
-  noSpeechThreshold: 0.60,
+  noSpeechThreshold: 0.6,
   lowQualityThreshold: -0.55,
 }
 


### PR DESCRIPTION
- Removed 'Detailed Examples' button from Intelligent Mode onboarding page
- Updated default no speech threshold from 0.35 to 0.60 for improved voice detection