### PR TITLE
Fix onboarding hotkeys: replace defaults, enforce exclusivity, sync UI

### DIFF
--- a/app/components/welcome/contents/IntroducingIntelligentModeContent.tsx
+++ b/app/components/welcome/contents/IntroducingIntelligentModeContent.tsx
@@ -11,8 +11,11 @@ export default function IntroducingIntelligentMode() {
   const { incrementOnboardingStep, decrementOnboardingStep } =
     useOnboardingStore()
 
-  const { getItoModeShortcuts, addKeyboardShortcut } = useSettingsStore()
-  const keyboardShortcut = getItoModeShortcuts(ItoMode.EDIT)[0].keys
+  const keyboardShortcut = useSettingsStore(state => {
+    const rows = state.keyboardShortcuts.filter(ks => ks.mode === ItoMode.EDIT)
+    return rows[0]?.keys ?? []
+  })
+  const { setOnboardingHotkey } = useSettingsStore()
 
   return (
     <div className="flex flex-row h-full w-full bg-background">
@@ -75,7 +78,7 @@ export default function IntroducingIntelligentMode() {
       <div className="flex w-[55%] items-center justify-center bg-gradient-to-b from-purple-50/10 to-purple-100 border-l-2 border-purple-100">
         <KeyboardShortcutEditor
           shortcut={keyboardShortcut}
-          onShortcutChange={addKeyboardShortcut}
+          onShortcutChange={setOnboardingHotkey}
           keySize={80}
           editButtonText="Change Shortcut"
           showConfirmButton={true}

--- a/app/components/welcome/contents/KeyboardTestContext.tsx
+++ b/app/components/welcome/contents/KeyboardTestContext.tsx
@@ -6,8 +6,13 @@ import { ItoMode } from '@/app/generated/ito_pb'
 export default function KeyboardTestContent() {
   const { incrementOnboardingStep, decrementOnboardingStep } =
     useOnboardingStore()
-  const { getItoModeShortcuts, addKeyboardShortcut } = useSettingsStore()
-  const keyboardShortcut = getItoModeShortcuts(ItoMode.TRANSCRIBE)[0].keys
+  const keyboardShortcut = useSettingsStore(state => {
+    const rows = state.keyboardShortcuts.filter(
+      ks => ks.mode === ItoMode.TRANSCRIBE,
+    )
+    return rows[0]?.keys ?? []
+  })
+  const { setOnboardingHotkey } = useSettingsStore()
 
   return (
     <div className="flex flex-row h-full w-full bg-background">
@@ -37,7 +42,7 @@ export default function KeyboardTestContent() {
       <div className="flex w-[55%] items-center justify-center bg-gradient-to-b from-purple-50/10 to-purple-100 border-l-2 border-purple-100">
         <KeyboardShortcutEditor
           shortcut={keyboardShortcut}
-          onShortcutChange={addKeyboardShortcut}
+          onShortcutChange={setOnboardingHotkey}
           keySize={80}
           editButtonText="No, change shortcut"
           confirmButtonText="Yes"

--- a/app/store/useSettingsStore.ts
+++ b/app/store/useSettingsStore.ts
@@ -25,7 +25,10 @@ interface SettingsState {
   microphoneDeviceId: string
   microphoneName: string
   keyboardShortcuts: KeyboardShortcutConfig[]
-  hotkeySource: { transcribe: 'onboarding' | 'user'; edit: 'onboarding' | 'user' }
+  hotkeySource: {
+    transcribe: 'onboarding' | 'user'
+    edit: 'onboarding' | 'user'
+  }
   setShareAnalytics: (share: boolean) => void
   setLaunchAtLogin: (launch: boolean) => void
   setShowItoBarAlways: (show: boolean) => void
@@ -248,7 +251,10 @@ export const useSettingsStore = create<SettingsState>(set => {
 
       // Dedupe within same mode
       const dupInSameMode = currentShortcuts.some(
-        ks => ks.mode === mode && ks.id !== shortcutId && stringifyChord(ks.keys) === stringifyChord(normalized),
+        ks =>
+          ks.mode === mode &&
+          ks.id !== shortcutId &&
+          stringifyChord(ks.keys) === stringifyChord(normalized),
       )
       if (dupInSameMode) {
         analytics.track('hotkey_settings_add_attempt' as any, {
@@ -261,11 +267,12 @@ export const useSettingsStore = create<SettingsState>(set => {
       }
 
       // Cross-mode conflict
-      const otherModeChord = state
-        .keyboardShortcuts
+      const otherModeChord = state.keyboardShortcuts
         .filter(ks => ks.mode === otherMode)
         .map(ks => ks.keys)
-      const hasConflict = otherModeChord.some(ch => detectConflict(ch, normalized))
+      const hasConflict = otherModeChord.some(ch =>
+        detectConflict(ch, normalized),
+      )
       if (hasConflict) {
         analytics.track('hotkey_conflict_blocked' as any, {
           chord: normalized,
@@ -285,7 +292,11 @@ export const useSettingsStore = create<SettingsState>(set => {
       )
       const partialState = {
         keyboardShortcuts: updatedShortcuts,
-        hotkeySource: { ...state.hotkeySource, [mode === ItoMode.TRANSCRIBE ? 'transcribe' : 'edit']: 'user' as const },
+        hotkeySource: {
+          ...state.hotkeySource,
+          [mode === ItoMode.TRANSCRIBE ? 'transcribe' : 'edit']:
+            'user' as const,
+        },
       }
       // Track keyboard shortcut change
       analytics.trackSettings(ANALYTICS_EVENTS.KEYBOARD_SHORTCUTS_CHANGED, {
@@ -330,7 +341,9 @@ export const useSettingsStore = create<SettingsState>(set => {
 
       let otherUpdated = false
       let nextOtherShortcuts = otherShortcuts
-      const conflictWithOther = otherShortcuts.some(ks => detectConflict(ks.keys, normalized))
+      const conflictWithOther = otherShortcuts.some(ks =>
+        detectConflict(ks.keys, normalized),
+      )
       if (conflictWithOther) {
         const disallowed = [normalized]
         const fallback = pickFallback(platform, disallowed)
@@ -359,7 +372,7 @@ export const useSettingsStore = create<SettingsState>(set => {
       }
 
       const rebuilt = [
-        ...filtered.filter(ks => ks.mode === otherMode ? false : true),
+        ...filtered.filter(ks => (ks.mode === otherMode ? false : true)),
         // Put enforced other mode shortcuts
         ...nextOtherShortcuts,
         // Finally our single hotkey for current mode

--- a/app/utils/hotkeysManager.ts
+++ b/app/utils/hotkeysManager.ts
@@ -1,0 +1,137 @@
+import { ItoMode } from '@/app/generated/ito_pb'
+
+type Platform = 'darwin' | 'win32' | 'linux' | 'unknown'
+
+const MODIFIER_ORDER = ['control', 'option', 'shift', 'command', 'fn'] as const
+
+function sortKeysCanonical(keys: string[]): string[] {
+  const unique = Array.from(new Set(keys.map(k => k.toLowerCase())))
+  const modifiers: string[] = []
+  const nonModifiers: string[] = []
+  for (const key of unique) {
+    if ((MODIFIER_ORDER as readonly string[]).includes(key)) modifiers.push(key)
+    else nonModifiers.push(key)
+  }
+  modifiers.sort(
+    (a, b) => MODIFIER_ORDER.indexOf(a as any) - MODIFIER_ORDER.indexOf(b as any),
+  )
+  nonModifiers.sort()
+  return [...modifiers, ...nonModifiers]
+}
+
+export function normalizeChord(keys: string[]): string[] {
+  return sortKeysCanonical(keys.filter(Boolean))
+}
+
+export function chordsEqual(a: string[], b: string[]): boolean {
+  const aa = normalizeChord(a)
+  const bb = normalizeChord(b)
+  if (aa.length !== bb.length) return false
+  return aa.every((k, i) => k === bb[i])
+}
+
+export function detectConflict(a: string[], b: string[]): boolean {
+  return chordsEqual(a, b)
+}
+
+export function pickFallback(platform: Platform, disallowed: string[][] = []): string[] {
+  const normalizedDisallowed = disallowed.map(normalizeChord)
+  const isAllowed = (candidate: string[]) =>
+    !normalizedDisallowed.some(c => chordsEqual(c, candidate))
+
+  // Preferred fallback: fn (macOS only)
+  if (platform === 'darwin') {
+    const candidate = ['fn']
+    if (isAllowed(candidate)) return candidate
+  }
+
+  // Cross-platform fallback: option+space (Alt+Space on Windows)
+  const altSpace = ['option', 'space']
+  if (isAllowed(altSpace)) return altSpace
+
+  // Secondary fallback: control+space
+  const ctrlSpace = ['control', 'space']
+  if (isAllowed(ctrlSpace)) return ctrlSpace
+
+  // Last resort: shift+space
+  const shiftSpace = ['shift', 'space']
+  if (isAllowed(shiftSpace)) return shiftSpace
+
+  // Give up, return empty (caller should handle)
+  return []
+}
+
+export function getOtherMode(mode: ItoMode): ItoMode {
+  return mode === ItoMode.TRANSCRIBE ? ItoMode.EDIT : ItoMode.TRANSCRIBE
+}
+
+export function stringifyChord(keys: string[]): string {
+  return normalizeChord(keys).join('+')
+}
+
+export function dedupeWithinMode<T extends { keys: string[]; mode: ItoMode }>(
+  rows: T[],
+): T[] {
+  const seenByMode = new Map<ItoMode, Set<string>>()
+  const result: T[] = []
+  for (const row of rows) {
+    const norm = stringifyChord(row.keys)
+    const set = seenByMode.get(row.mode) ?? new Set<string>()
+    if (!set.has(norm)) {
+      set.add(norm)
+      seenByMode.set(row.mode, set)
+      result.push(row)
+    }
+  }
+  return result
+}
+
+export function resolveCrossModeConflicts<T extends { keys: string[]; mode: ItoMode }>(
+  rows: T[],
+  platform: Platform,
+): T[] {
+  // Build maps of chords by mode
+  const byMode = new Map<ItoMode, Map<string, T>>()
+  for (const row of rows) {
+    const norm = stringifyChord(row.keys)
+    const map = byMode.get(row.mode) ?? new Map<string, T>()
+    map.set(norm, row)
+    byMode.set(row.mode, map)
+  }
+
+  const tMap = byMode.get(ItoMode.TRANSCRIBE) ?? new Map<string, T>()
+  const eMap = byMode.get(ItoMode.EDIT) ?? new Map<string, T>()
+
+  // For each conflicting chord present in both maps, move the EDIT one to a fallback
+  for (const chord of Array.from(tMap.keys())) {
+    if (eMap.has(chord)) {
+      const editRow = eMap.get(chord)!
+      const disallowed = [Array.from(chord.split('+'))]
+      const fallback = pickFallback(platform, disallowed)
+      editRow.keys = fallback
+      // Update key in map
+      eMap.delete(chord)
+      eMap.set(stringifyChord(fallback), editRow)
+    }
+  }
+
+  return [...tMap.values(), ...eMap.values()]
+}
+
+export async function detectPlatform(): Promise<Platform> {
+  try {
+    const info = await window.api.invoke('init-window')
+    const p = info?.platform as string | undefined
+    if (p === 'darwin' || p === 'win32' || p === 'linux') return p
+  } catch (_) {
+    // Silent catch - fallback to user agent detection
+  }
+  // fallback
+  const ua = (navigator?.platform || '').toLowerCase()
+  if (ua.includes('mac')) return 'darwin'
+  if (ua.includes('win')) return 'win32'
+  if (ua.includes('linux')) return 'linux'
+  return 'unknown'
+}
+
+

--- a/app/utils/hotkeysManager.ts
+++ b/app/utils/hotkeysManager.ts
@@ -13,7 +13,8 @@ function sortKeysCanonical(keys: string[]): string[] {
     else nonModifiers.push(key)
   }
   modifiers.sort(
-    (a, b) => MODIFIER_ORDER.indexOf(a as any) - MODIFIER_ORDER.indexOf(b as any),
+    (a, b) =>
+      MODIFIER_ORDER.indexOf(a as any) - MODIFIER_ORDER.indexOf(b as any),
   )
   nonModifiers.sort()
   return [...modifiers, ...nonModifiers]
@@ -34,7 +35,10 @@ export function detectConflict(a: string[], b: string[]): boolean {
   return chordsEqual(a, b)
 }
 
-export function pickFallback(platform: Platform, disallowed: string[][] = []): string[] {
+export function pickFallback(
+  platform: Platform,
+  disallowed: string[][] = [],
+): string[] {
   const normalizedDisallowed = disallowed.map(normalizeChord)
   const isAllowed = (candidate: string[]) =>
     !normalizedDisallowed.some(c => chordsEqual(c, candidate))
@@ -86,10 +90,9 @@ export function dedupeWithinMode<T extends { keys: string[]; mode: ItoMode }>(
   return result
 }
 
-export function resolveCrossModeConflicts<T extends { keys: string[]; mode: ItoMode }>(
-  rows: T[],
-  platform: Platform,
-): T[] {
+export function resolveCrossModeConflicts<
+  T extends { keys: string[]; mode: ItoMode },
+>(rows: T[], platform: Platform): T[] {
   // Build maps of chords by mode
   const byMode = new Map<ItoMode, Map<string, T>>()
   for (const row of rows) {
@@ -133,5 +136,3 @@ export async function detectPlatform(): Promise<Platform> {
   if (ua.includes('linux')) return 'linux'
   return 'unknown'
 }
-
-

--- a/lib/main/store.ts
+++ b/lib/main/store.ts
@@ -30,7 +30,10 @@ export interface SettingsStore {
   microphoneName: string
   isShortcutGloballyEnabled: boolean
   keyboardShortcuts: KeyboardShortcutConfig[]
-  hotkeySource?: { transcribe: 'onboarding' | 'user'; edit: 'onboarding' | 'user' }
+  hotkeySource?: {
+    transcribe: 'onboarding' | 'user'
+    edit: 'onboarding' | 'user'
+  }
   firstName: string
   lastName: string
   email: string
@@ -194,8 +197,7 @@ const migrations: Migration[] = [
       const platform = process.platform as 'darwin' | 'win32' | 'linux'
 
       const norm = (keys: string[]) =>
-        [...new Set(keys.map(k => k.toLowerCase()))]
-          .sort()
+        [...new Set(keys.map(k => k.toLowerCase()))].sort()
       const keyOf = (keys: string[]) => norm(keys).join('+')
 
       // Dedupe within each mode
@@ -206,7 +208,8 @@ const migrations: Migration[] = [
       }
       for (const row of shortcuts) {
         const k = keyOf(row.keys)
-        const map = byMode[row.mode] ?? new Map<string, KeyboardShortcutConfig>()
+        const map =
+          byMode[row.mode] ?? new Map<string, KeyboardShortcutConfig>()
         if (!map.has(k)) map.set(k, row)
         else dedupedCount += 1
         byMode[row.mode] = map
@@ -225,7 +228,8 @@ const migrations: Migration[] = [
 
       const pickFallback = (disallowed: string[]): string[] => {
         const disallowKeys = new Set(disallowed)
-        const allow = (candidate: string[]) => !disallowKeys.has(keyOf(candidate))
+        const allow = (candidate: string[]) =>
+          !disallowKeys.has(keyOf(candidate))
         if (platform === 'darwin') {
           const fn = ['fn']
           if (allow(fn)) return fn
@@ -241,7 +245,8 @@ const migrations: Migration[] = [
 
       for (const chord of Array.from(tMap.keys())) {
         if (eMap.has(chord)) {
-          const keepTranscribe = source.transcribe === 'onboarding' || source.edit === 'user'
+          const keepTranscribe =
+            source.transcribe === 'onboarding' || source.edit === 'user'
           // Move EDIT to fallback
           const editRow = eMap.get(chord)!
           const fallback = pickFallback([chord])


### PR DESCRIPTION
Description:

Problem: Changing a hotkey during onboarding appends a new binding (doesn’t replace default), UI doesn’t update, and the same hotkey can be assigned to Dictate & Intelligent, causing conflicts.

Fix:

Replace (don’t append) the selected onboarding hotkey per mode.

Enforce uniqueness across modes; block duplicates with clear feedback.

When Dictate = Ctrl, auto-set Intelligent = FN (mutually exclusive default).

Immediately propagate onboarding selections to settings/state so the UI reflects them.

Multiple hotkeys can be added only later in Settings.