### PR TITLE
Update website link from heyito.ai to ito.ai

### DIFF
--- a/app/components/home/contents/AboutContent.tsx
+++ b/app/components/home/contents/AboutContent.tsx
@@ -108,7 +108,7 @@ export default function AboutContent() {
 
           <AboutCard
             icon={<Globe className="w-6 h-6 text-black" />}
-            title="heyito.ai"
+            title="ito.ai"
             description="Learn more about Ito, explore features, and see what's next."
             buttonText="Go to Website"
             onClick={handleWebsiteClick}


### PR DESCRIPTION
## Summary
- Updated the website link in the About page from heyito.ai to ito.ai

## Test plan
- [ ] Verify the About page displays "ito.ai" instead of "heyito.ai"  
- [ ] Confirm the website button still functions correctly