### PR TITLE
Fix multi-channel downsampling

### DIFF
--- a/.cursor/rules/always.mdc
+++ b/.cursor/rules/always.mdc
@@ -6,7 +6,6 @@ alwaysApply: true
 ## Development cycle
 
 1. Before writing any code, come up with an extremely good plan, review the plan, and then ask the user for permission to execute the plan.
-2. Never try to start a dev server or curl a local endpoint.
+2. Always rely on the user for manually testing and code changes
 3. Always use bun as your preferred package manager.
-4. NEVER run the app on your own via bun dev, bun run dev, etc.
-5. NEVER attempt to install any new packages on your own.
+4. Always rely on the user to install new packages / update new packages

--- a/app/components/home/contents/HomeContent.tsx
+++ b/app/components/home/contents/HomeContent.tsx
@@ -383,7 +383,10 @@ export default function HomeContent() {
 
         try {
           // If direct playback fails, try converting raw PCM to WAV
-          const wavBuffer = createWavFile(pcmData)
+          const wavBuffer = createWavFile(
+            pcmData,
+            interaction.sample_rate || 16000,
+          )
           audioBlob = new Blob([wavBuffer], { type: 'audio/wav' })
           audioUrl = URL.createObjectURL(audioBlob)
 

--- a/lib/main/sqlite/migrations.ts
+++ b/lib/main/sqlite/migrations.ts
@@ -15,4 +15,9 @@ export const MIGRATIONS: Migration[] = [
     up: 'ALTER TABLE interactions ADD COLUMN duration_ms INTEGER DEFAULT 0;',
     down: 'ALTER TABLE interactions DROP COLUMN duration_ms;',
   },
+  {
+    id: '20250110120000_add_sample_rate_to_interactions',
+    up: 'ALTER TABLE interactions ADD COLUMN sample_rate INTEGER;',
+    down: 'ALTER TABLE interactions DROP COLUMN sample_rate;',
+  },
 ]

--- a/lib/main/sqlite/models.ts
+++ b/lib/main/sqlite/models.ts
@@ -6,6 +6,7 @@ export interface Interaction {
   llm_output: any
   raw_audio: Buffer | null
   duration_ms: number | null
+  sample_rate: number | null
   created_at: string
   updated_at: string
   deleted_at: string | null

--- a/lib/main/sqlite/repo.ts
+++ b/lib/main/sqlite/repo.ts
@@ -54,8 +54,8 @@ export class InteractionsTable {
     }
 
     const query = `
-      INSERT INTO interactions (id, user_id, title, asr_output, llm_output, raw_audio, duration_ms, created_at, updated_at, deleted_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO interactions (id, user_id, title, asr_output, llm_output, raw_audio, duration_ms, sample_rate, created_at, updated_at, deleted_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `
     // Note: SQLite doesn't have a dedicated JSON type, so we stringify complex objects
     const params = [
@@ -66,6 +66,7 @@ export class InteractionsTable {
       JSON.stringify(newInteraction.llm_output),
       newInteraction.raw_audio,
       newInteraction.duration_ms,
+      newInteraction.sample_rate,
       newInteraction.created_at,
       newInteraction.updated_at,
       newInteraction.deleted_at,
@@ -120,14 +121,15 @@ export class InteractionsTable {
 
   static async upsert(interaction: Interaction): Promise<void> {
     const query = `
-      INSERT INTO interactions (id, user_id, title, asr_output, llm_output, raw_audio, duration_ms, created_at, updated_at, deleted_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO interactions (id, user_id, title, asr_output, llm_output, raw_audio, duration_ms, sample_rate, created_at, updated_at, deleted_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         title = excluded.title,
         asr_output = excluded.asr_output,
         llm_output = excluded.llm_output,
         raw_audio = excluded.raw_audio,
         duration_ms = excluded.duration_ms,
+        sample_rate = excluded.sample_rate,
         updated_at = excluded.updated_at,
         deleted_at = excluded.deleted_at;
     `
@@ -139,6 +141,7 @@ export class InteractionsTable {
       JSON.stringify(interaction.llm_output),
       interaction.raw_audio,
       interaction.duration_ms,
+      interaction.sample_rate,
       interaction.created_at,
       interaction.updated_at,
       interaction.deleted_at,

--- a/lib/main/transcriptionService.ts
+++ b/lib/main/transcriptionService.ts
@@ -17,6 +17,7 @@ export class TranscriptionService {
   private currentInteractionId: string | null = null
   private audioChunksForInteraction: Buffer[] = []
   private interactionStartTime: number | null = null
+  private currentSampleRate: number = 16000
 
   private async *streamAudioChunks() {
     while (this.isStreaming) {
@@ -261,6 +262,7 @@ export class TranscriptionService {
         llm_output: null, // No LLM processing yet
         raw_audio: rawAudio,
         duration_ms: durationMs, // Add duration as separate field
+        sample_rate: this.currentSampleRate || null,
         created_at: now,
         updated_at: now,
         deleted_at: null,
@@ -315,6 +317,13 @@ export class TranscriptionService {
 
   public handleAudioChunk(chunk: Buffer) {
     return this.forwardAudioChunk(chunk)
+  }
+
+  public setAudioConfig(config: { sampleRate?: number; channels?: number }) {
+    console.log('[TranscriptionService] Setting audio config:', config)
+    if (typeof config.sampleRate === 'number' && config.sampleRate > 0) {
+      this.currentSampleRate = config.sampleRate
+    }
   }
 }
 

--- a/lib/main/voiceInputService.ts
+++ b/lib/main/voiceInputService.ts
@@ -62,6 +62,14 @@ export class VoiceInputService {
   }
 
   public setUpAudioRecorderListeners = () => {
+    audioRecorderService.on(
+      'audio-config',
+      ({ outputSampleRate, sampleRate }: any) => {
+        // Use the recorder's effective output rate (matches the PCM we store)
+        const effectiveRate = outputSampleRate || sampleRate || 16000
+        transcriptionService.setAudioConfig({ sampleRate: effectiveRate })
+      },
+    )
     audioRecorderService.on('audio-chunk', chunk => {
       transcriptionService.handleAudioChunk(chunk)
     })
@@ -83,6 +91,14 @@ export class VoiceInputService {
     })
 
     audioRecorderService.initialize()
+  }
+
+  /**
+   * Call this when microphone selection changes to update the transcription
+   * config with the effective output sample rate for the chosen device.
+   */
+  public handleMicrophoneChanged = (deviceId: string) => {
+    audioRecorderService.requestDeviceConfig(deviceId)
   }
 }
 

--- a/lib/media/audio.ts
+++ b/lib/media/audio.ts
@@ -126,6 +126,14 @@ class AudioRecorderService extends EventEmitter {
     })
   }
 
+  /**
+   * Requests the effective output audio configuration (sample rate, channels)
+   * that the recorder will use for a given device. Resolves via 'audio-config'.
+   */
+  public requestDeviceConfig(deviceName: string): void {
+    this.#sendCommand({ command: 'get-device-config', device_name: deviceName })
+  }
+
   // --- Private Methods ---
 
   /**
@@ -205,6 +213,15 @@ class AudioRecorderService extends EventEmitter {
         if (jsonResponse.type === 'device-list' && this.#deviceListPromise) {
           this.#deviceListPromise.resolve(jsonResponse.devices || [])
           this.#deviceListPromise = null
+        } else if (jsonResponse.type === 'audio-config') {
+          const inputRate = Number(jsonResponse.input_sample_rate) || 16000
+          const outputRate = Number(jsonResponse.output_sample_rate) || 16000
+          const channels = Number(jsonResponse.channels) || 1
+          this.emit('audio-config', {
+            sampleRate: inputRate,
+            outputSampleRate: outputRate,
+            channels,
+          })
         }
         // You could emit a generic 'json-message' event here if needed
       } catch (err) {

--- a/lib/window/ipcEvents.ts
+++ b/lib/window/ipcEvents.ts
@@ -507,6 +507,12 @@ ipcMain.on('volume-update', (_event, volume: number) => {
 // Forwards settings updates from the main window to the pill window
 ipcMain.on('settings-update', (_event, settings: any) => {
   getPillWindow()?.webContents.send('settings-update', settings)
+
+  // If microphone selection changed, ensure TranscriptionService config is set
+  if (settings && typeof settings.microphoneDeviceId === 'string') {
+    // Ask the recorder for the effective output config for the selected mic
+    voiceInputService.handleMicrophoneChanged(settings.microphoneDeviceId)
+  }
 })
 
 // Forwards onboarding updates from the main window to the pill window


### PR DESCRIPTION
The Zoom H6 was sending multi‑channel 32‑bit float audio, but we treated the interleaved channels as if they were mono 16‑bit PCM. That broke the timebase and sample interpretation, so WAVs played at the wrong speed/pitch (and sounded quiet).
Fix: downmix input to mono before resampling/quantizing to 16‑bit PCM, and use the recorder’s actual output sample rate when creating WAV headers.

As a part of this ticket I chased a bit of a red herring before figuring out the real root cause and as a result we now have some plumbing that exposes mic sample rate to the app. I think this plumbing is worth keeping in as it may be useful in the future.