### PR TITLE
Switch close and minimize buttons for interim

### DIFF
--- a/app/components/window/Titlebar.tsx
+++ b/app/components/window/Titlebar.tsx
@@ -210,13 +210,13 @@ const TitlebarControls = () => {
 
   return (
     <div className="window-titlebar-controls">
-      {wcontext?.minimizable && (
-        <TitlebarControlButton label="minimize" svgPath={minimizePath} />
-      )}
+      <TitlebarControlButton label="close" svgPath={closePath} />
       {wcontext?.maximizable && (
         <TitlebarControlButton label="maximize" svgPath={maximizePath} />
       )}
-      <TitlebarControlButton label="close" svgPath={closePath} />
+      {wcontext?.minimizable && (
+        <TitlebarControlButton label="minimize" svgPath={minimizePath} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Eventually we're gonna need some designs to move the buttons to the upper right, but having them on the left for now is fine