### PR TITLE
Race condition fix for text writer

### DIFF
--- a/native/text-writer/src/macos_writer.rs
+++ b/native/text-writer/src/macos_writer.rs
@@ -26,7 +26,6 @@ pub fn type_text_macos(text: &str, _char_delay: u64) -> Result<(), String> {
         pasteboard.setString_forType(ns_string, NSPasteboardTypeString);
 
         // Verify clipboard was actually set by reading it back
-        // This ensures macOS has processed the clipboard change
         let mut attempts = 0;
         loop {
             let current_content = pasteboard.stringForType(NSPasteboardTypeString);
@@ -64,11 +63,10 @@ pub fn type_text_macos(text: &str, _char_delay: u64) -> Result<(), String> {
 
         // Post the events
         key_v_down.post(core_graphics::event::CGEventTapLocation::HID);
-        thread::sleep(Duration::from_millis(5)); // Minimal delay between press and release
+        thread::sleep(Duration::from_millis(10));
         key_v_up.post(core_graphics::event::CGEventTapLocation::HID);
 
-        // Restore old clipboard contents in background after generous delay
-        // This prevents blocking while giving ample time for paste to complete
+        // Restore old clipboard contents in background after delay in separate thread to not block 
         if old_contents != nil {
             thread::spawn(move || unsafe {
                 thread::sleep(Duration::from_secs(1));

--- a/native/text-writer/src/windows_writer.rs
+++ b/native/text-writer/src/windows_writer.rs
@@ -15,7 +15,6 @@ pub fn type_text_windows(text: &str, _char_delay: u64) -> Result<(), String> {
         .map_err(|e| format!("Failed to set clipboard: {:?}", e))?;
 
     // Verify clipboard was actually set by reading it back
-    // This ensures Windows has processed the clipboard change
     let mut attempts = 0;
     loop {
         match get_clipboard::<String, _>(formats::Unicode) {
@@ -43,8 +42,8 @@ pub fn type_text_windows(text: &str, _char_delay: u64) -> Result<(), String> {
     enigo.key(Key::Unicode('v'), enigo::Direction::Press)
         .map_err(|e| format!("Failed to press V: {}", e))?;
 
-    // Small delay between press and release to ensure it's registered
-    thread::sleep(Duration::from_millis(5));
+    // Small delay to ensure the key press is registered
+    thread::sleep(Duration::from_millis(20));
 
     // Release V
     enigo.key(Key::Unicode('v'), enigo::Direction::Release)
@@ -54,9 +53,6 @@ pub fn type_text_windows(text: &str, _char_delay: u64) -> Result<(), String> {
     enigo.key(Key::Control, enigo::Direction::Release)
         .map_err(|e| format!("Failed to release Ctrl: {}", e))?;
 
-    // Restore old clipboard contents in background after generous delay
-    // This prevents blocking while giving ample time for paste to complete
-    // and reduces chance of user interference
     if let Ok(old_text) = old_contents {
         thread::spawn(move || {
             thread::sleep(Duration::from_secs(1));


### PR DESCRIPTION
Checks the clipboard has been properly adjusted first, then waits at the end on a separate thread as not to block to set the clipboard back to original contents. 1s is still ultimately arbitrary but since its not blocking anymore felt it was a long enough safe time to wait without impacting user. 