### PR TITLE
ITO-254: Grammar Selection Service Sometimes Overwrites Post-Cursor Text

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,12 @@
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "rust-analyzer.linkedProjects": [
+    "./native/selected-text-reader/Cargo.toml",
+    "./native/text-writer/Cargo.toml",
+    "./native/audio-recorder/Cargo.toml",
+    "./native/active-application/Cargo.toml",
+    "./native/global-key-listener/Cargo.toml"
+  ]
 }

--- a/lib/media/selected-text-reader.ts
+++ b/lib/media/selected-text-reader.ts
@@ -315,36 +315,11 @@ export async function hasSelectedText(): Promise<boolean> {
  * Get cursor context using the new getCursorContext functionality
  */
 export async function getCursorContext(contextLength: number): Promise<string> {
-  // find out if we have a highlighted selection already
-  const selectedText = (await getSelectedTextString(100)) || ''
-
   const cursorContextResult = await selectedTextReaderService.getCursorContext(
     contextLength,
     false,
   )
-  let preCursorText = cursorContextResult.contextText || ''
-
-  // No selected text, just get cursor context
-  if (selectedText.length === 0) {
-    return preCursorText
-  }
-
-  // If the pre-cursor text includes the selected text,
-  // we probably extended the highlighted portion, and can simply return the difference
-  // between the pre-cursor text and the selected text
-  const selectedTextIndex = preCursorText.indexOf(selectedText)
-  if (selectedTextIndex !== -1) {
-    console.log('[SelectedTextService] Selected text found in pre-cursor text')
-    preCursorText = preCursorText.slice(0, selectedTextIndex)
-    return preCursorText
-  }
-
-  // If the pre-cursor text is a subsection of selectedText, we probably deselected some text instead
-  // of getting actual pre-cursor text. Rather than trying to cut the selected text and get the
-  // pre-cursor text again, just return an empty string.
-  if (selectedText.includes(preCursorText)) {
-    return ''
-  }
+  const preCursorText = cursorContextResult.contextText || ''
 
   return preCursorText
 }

--- a/native/selected-text-reader/src/cross_platform.rs
+++ b/native/selected-text-reader/src/cross_platform.rs
@@ -4,23 +4,25 @@ use std::time::Duration;
 
 pub fn get_selected_text() -> Result<String, Box<dyn std::error::Error>> {
     let mut clipboard = Clipboard::new().map_err(|e| format!("Clipboard init failed: {}", e))?;
-    
+
     // Store original clipboard contents
     let original_clipboard = clipboard.get_text().unwrap_or_default();
-    
-    clipboard.clear().map_err(|e| format!("Clipboard clear failed: {}", e))?;
-    
+
+    clipboard
+        .clear()
+        .map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
     copy_selected_text()?;
-    
+
     // Small delay for copy operation to complete
     thread::sleep(Duration::from_millis(25));
-    
+
     // Get the copy text from clipboard (this is what was selected)
     let selected_text = clipboard.get_text().unwrap_or_default();
-    
+
     // Always restore original clipboard contents - ITO is copying on behalf of user for context
     let _ = clipboard.set_text(original_clipboard);
-    
+
     Ok(selected_text)
 }
 
@@ -72,115 +74,175 @@ pub fn get_cursor_context(context_length: usize) -> Result<String, Box<dyn std::
     // Use keyboard commands to get cursor context
     // This is more reliable across different applications than Accessibility API
     let mut clipboard = Clipboard::new().map_err(|e| format!("Clipboard init failed: {}", e))?;
-    
+
     // Store original clipboard contents
     let original_clipboard = clipboard.get_text().unwrap_or_default();
-    
-    let result = get_context_with_keyboard_selection(context_length, &mut clipboard);
-    
+
+    // First, get any existing selected text
+    clipboard
+        .clear()
+        .map_err(|e| format!("Clipboard clear failed: {}", e))?;
+    copy_selected_text()?;
+    thread::sleep(Duration::from_millis(25));
+    let selected_text = clipboard.get_text().unwrap_or_default();
+    let selected_char_count = selected_text.chars().count();
+
+    let context_text = if selected_char_count == 0 {
+        // Case 1: No selected text - proceed normally with cursor context
+        clipboard
+            .clear()
+            .map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
+        let result = select_previous_chars_and_copy(context_length, &mut clipboard);
+        match result {
+            Ok(precursor_text) => {
+                let precursor_char_count = precursor_text.chars().count();
+                // Shift right by the amount we grabbed
+                if precursor_char_count > 0 {
+                    let _ = shift_cursor_right_with_deselect(precursor_char_count);
+                }
+                precursor_text
+            }
+            Err(e) => format!("[ERROR] {}", e),
+        }
+    } else {
+        // Case 2: Some text already selected - try extending by one character
+        clipboard
+            .clear()
+            .map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
+        let result = select_previous_chars_and_copy(1, &mut clipboard);
+        match result {
+            Ok(extended_text) => {
+                let extended_char_count = extended_text.chars().count();
+
+                if extended_char_count < selected_char_count {
+                    // Selection shrunk - undo and return empty
+                    let _ = shift_cursor_right_with_deselect(1);
+                    String::new()
+                } else if extended_char_count == selected_char_count {
+                    // Selection unchanged - return empty, no need to return cursor
+                    String::new()
+                } else {
+                    // Selection extended successfully - continue extending to get full context_length
+                    clipboard
+                        .clear()
+                        .map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
+                    let full_result =
+                        select_previous_chars_and_copy(context_length, &mut clipboard);
+                    match full_result {
+                        Ok(full_context_text) => {
+                            let full_context_char_count = full_context_text.chars().count();
+                            // Undo by the absolute difference between original selected text and total selection
+                            let chars_to_undo = (full_context_char_count as i32
+                                - selected_char_count as i32)
+                                .abs() as usize;
+                            if chars_to_undo > 0 {
+                                let _ = shift_cursor_right_with_deselect(chars_to_undo);
+                            }
+
+                            // Return only the newly added context (first n characters where n is the difference)
+                            let new_context_char_count =
+                                full_context_char_count - selected_char_count;
+                            full_context_text
+                                .chars()
+                                .take(new_context_char_count)
+                                .collect()
+                        }
+                        Err(e) => format!("[ERROR] {}", e),
+                    }
+                }
+            }
+            Err(e) => format!("[ERROR] {}", e),
+        }
+    };
+
     // Always restore original clipboard
     let _ = clipboard.set_text(original_clipboard);
-    
-    // Return debug info if we got nothing
-    match result {
-        Ok(ref text) if text.is_empty() => {
-            Ok(format!("[DEBUG] Empty result - check console for details"))
-        }
-        Ok(text) => Ok(text),
-        Err(e) => Ok(format!("[ERROR] {}", e)),
-    }
+
+    Ok(context_text)
 }
 
-fn get_context_with_keyboard_selection(
-    context_length: usize,
+// Simple function to select previous N characters and copy them
+fn select_previous_chars_and_copy(
+    char_count: usize,
     clipboard: &mut Clipboard,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    #[cfg(target_os = "windows")]
-    {
-        // Use PowerShell to send Shift+Left repeatedly to select context
-        use std::process::Command;
-        let selection_script = format!(
-            r#"
-            Add-Type -AssemblyName System.Windows.Forms
-            for ($i = 0; $i -lt {}; $i++) {{
-                [System.Windows.Forms.SendKeys]::SendWait("+{{LEFT}}")
-                Start-Sleep -Milliseconds 1
-            }}
-            "#,
-            context_length
-        );
-        
-        let _output = Command::new("powershell")
-            .args(&["-Command", &selection_script])
-            .output()?;
-    }
-    
-    #[cfg(target_os = "linux")]
-    {
-        // Use xdotool to send Shift+Left repeatedly
-        use std::process::Command;
-        
-        for _ in 0..context_length {
+    // Send Shift+Left N times to select precursor text
+    for _ in 0..char_count {
+        #[cfg(target_os = "windows")]
+        {
+            use std::process::Command;
+            let _output = Command::new("powershell")
+                .args(&["-Command", "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.SendKeys]::SendWait('+{LEFT}')"])
+                .output()?;
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            use std::process::Command;
             let _ = Command::new("xdotool")
                 .args(&["key", "shift+Left"])
                 .output();
-            thread::sleep(Duration::from_millis(2));
+        }
+
+        // Brief pause between selections
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    // Allow selection to complete
+    thread::sleep(Duration::from_millis(10));
+
+    copy_selected_text()?;
+    thread::sleep(Duration::from_millis(25)); // Wait for copy to complete
+
+    // Adaptively wait for and get text from clipboard
+    let mut context_text = String::new();
+    let max_retries = 20; // Poll for a maximum of 20 * 10ms = 200ms
+    for _ in 0..max_retries {
+        // Give a tiny bit of time for the clipboard to update
+        thread::sleep(Duration::from_millis(10));
+
+        if let Ok(text) = clipboard.get_text() {
+            if !text.is_empty() {
+                context_text = text;
+                break; // Success! We got the text.
+            }
         }
     }
-    
-    // Copy the selection
-    copy_selected_text()?;
-    
-    thread::sleep(Duration::from_millis(25));
-    
-    // Get the copied text
-    let context_text = clipboard.get_text().unwrap_or_default();
-    
-    // Restore cursor position by pressing shift + Right Arrow character times
-    
-    #[cfg(target_os = "windows")]
-    {
-        use std::process::Command;
-        let restore_script = format!(
-            r#"
-            Add-Type -AssemblyName System.Windows.Forms
-            for ($i = 0; $i -lt {}; $i++) {{
-                [System.Windows.Forms.SendKeys]::SendWait("+{{RIGHT}}")
-                Start-Sleep -Milliseconds 1
-            }}
-            "#,
-            context_length
-        );
-        
-        let _output = Command::new("powershell")
-            .args(&["-Command", &restore_script])
-            .output()?;
+
+    Ok(context_text)
+}
+
+// Shift cursor right while deselecting text
+fn shift_cursor_right_with_deselect(char_count: usize) -> Result<(), Box<dyn std::error::Error>> {
+    if char_count == 0 {
+        return Ok(());
     }
-    
-    #[cfg(target_os = "linux")]
-    {
-        use std::process::Command;
-        for _ in 0..context_length {
+
+    for _ in 0..char_count {
+        #[cfg(target_os = "windows")]
+        {
+            use std::process::Command;
+            let _output = Command::new("powershell")
+                .args(&["-Command", "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.SendKeys]::SendWait('+{RIGHT}')"])
+                .output()?;
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            use std::process::Command;
             let _ = Command::new("xdotool")
                 .args(&["key", "shift+Right"])
                 .output();
-            thread::sleep(Duration::from_millis(2));
+        }
+
+        // Brief pause between movements
+        if char_count > 1 {
+            thread::sleep(Duration::from_millis(1));
         }
     }
 
-    // Take only the last context_length characters
-    let final_context = if context_text.len() <= context_length {
-        context_text
-    } else {
-        context_text
-            .chars()
-            .rev()
-            .take(context_length)
-            .collect::<String>()
-            .chars()
-            .rev()
-            .collect()
-    };
-
-    Ok(final_context)
+    Ok(())
 }

--- a/native/selected-text-reader/src/cross_platform.rs
+++ b/native/selected-text-reader/src/cross_platform.rs
@@ -70,7 +70,6 @@ fn cut_selected_text() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-
 // Simple function to select previous N characters and copy them
 pub fn select_previous_chars_and_copy(
     char_count: usize,
@@ -102,7 +101,6 @@ pub fn select_previous_chars_and_copy(
     thread::sleep(Duration::from_millis(10));
 
     copy_selected_text()?;
-    thread::sleep(Duration::from_millis(25)); // Wait for copy to complete
 
     // Adaptively wait for and get text from clipboard
     let mut context_text = String::new();
@@ -123,7 +121,9 @@ pub fn select_previous_chars_and_copy(
 }
 
 // Shift cursor right while deselecting text
-pub fn shift_cursor_right_with_deselect(char_count: usize) -> Result<(), Box<dyn std::error::Error>> {
+pub fn shift_cursor_right_with_deselect(
+    char_count: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
     if char_count == 0 {
         return Ok(());
     }

--- a/native/selected-text-reader/src/cross_platform.rs
+++ b/native/selected-text-reader/src/cross_platform.rs
@@ -27,7 +27,7 @@ pub fn get_selected_text() -> Result<String, Box<dyn std::error::Error>> {
 }
 
 #[cfg(target_os = "windows")]
-fn copy_selected_text() -> Result<(), Box<dyn std::error::Error>> {
+pub fn copy_selected_text() -> Result<(), Box<dyn std::error::Error>> {
     use std::process::Command;
 
     // Use PowerShell to send Ctrl+C on Windows
@@ -39,7 +39,7 @@ fn copy_selected_text() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(target_os = "linux")]
-fn copy_selected_text() -> Result<(), Box<dyn std::error::Error>> {
+pub fn copy_selected_text() -> Result<(), Box<dyn std::error::Error>> {
     use std::process::Command;
 
     // Use xdotool to send Ctrl+C on Linux
@@ -70,102 +70,9 @@ fn cut_selected_text() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-pub fn get_cursor_context(context_length: usize) -> Result<String, Box<dyn std::error::Error>> {
-    // Use keyboard commands to get cursor context
-    // This is more reliable across different applications than Accessibility API
-    let mut clipboard = Clipboard::new().map_err(|e| format!("Clipboard init failed: {}", e))?;
-
-    // Store original clipboard contents
-    let original_clipboard = clipboard.get_text().unwrap_or_default();
-
-    // First, get any existing selected text
-    clipboard
-        .clear()
-        .map_err(|e| format!("Clipboard clear failed: {}", e))?;
-    copy_selected_text()?;
-    thread::sleep(Duration::from_millis(25));
-    let selected_text = clipboard.get_text().unwrap_or_default();
-    let selected_char_count = selected_text.chars().count();
-
-    let context_text = if selected_char_count == 0 {
-        // Case 1: No selected text - proceed normally with cursor context
-        clipboard
-            .clear()
-            .map_err(|e| format!("Clipboard clear failed: {}", e))?;
-
-        let result = select_previous_chars_and_copy(context_length, &mut clipboard);
-        match result {
-            Ok(precursor_text) => {
-                let precursor_char_count = precursor_text.chars().count();
-                // Shift right by the amount we grabbed
-                if precursor_char_count > 0 {
-                    let _ = shift_cursor_right_with_deselect(precursor_char_count);
-                }
-                precursor_text
-            }
-            Err(e) => format!("[ERROR] {}", e),
-        }
-    } else {
-        // Case 2: Some text already selected - try extending by one character
-        clipboard
-            .clear()
-            .map_err(|e| format!("Clipboard clear failed: {}", e))?;
-
-        let result = select_previous_chars_and_copy(1, &mut clipboard);
-        match result {
-            Ok(extended_text) => {
-                let extended_char_count = extended_text.chars().count();
-
-                if extended_char_count < selected_char_count {
-                    // Selection shrunk - undo and return empty
-                    let _ = shift_cursor_right_with_deselect(1);
-                    String::new()
-                } else if extended_char_count == selected_char_count {
-                    // Selection unchanged - return empty, no need to return cursor
-                    String::new()
-                } else {
-                    // Selection extended successfully - continue extending to get full context_length
-                    clipboard
-                        .clear()
-                        .map_err(|e| format!("Clipboard clear failed: {}", e))?;
-
-                    let full_result =
-                        select_previous_chars_and_copy(context_length, &mut clipboard);
-                    match full_result {
-                        Ok(full_context_text) => {
-                            let full_context_char_count = full_context_text.chars().count();
-                            // Undo by the absolute difference between original selected text and total selection
-                            let chars_to_undo = (full_context_char_count as i32
-                                - selected_char_count as i32)
-                                .abs() as usize;
-                            if chars_to_undo > 0 {
-                                let _ = shift_cursor_right_with_deselect(chars_to_undo);
-                            }
-
-                            // Return only the newly added context (first n characters where n is the difference)
-                            let new_context_char_count =
-                                full_context_char_count - selected_char_count;
-                            full_context_text
-                                .chars()
-                                .take(new_context_char_count)
-                                .collect()
-                        }
-                        Err(e) => format!("[ERROR] {}", e),
-                    }
-                }
-            }
-            Err(e) => format!("[ERROR] {}", e),
-        }
-    };
-
-    // Always restore original clipboard
-    let _ = clipboard.set_text(original_clipboard);
-
-    Ok(context_text)
-}
 
 // Simple function to select previous N characters and copy them
-fn select_previous_chars_and_copy(
+pub fn select_previous_chars_and_copy(
     char_count: usize,
     clipboard: &mut Clipboard,
 ) -> Result<String, Box<dyn std::error::Error>> {
@@ -216,7 +123,7 @@ fn select_previous_chars_and_copy(
 }
 
 // Shift cursor right while deselecting text
-fn shift_cursor_right_with_deselect(char_count: usize) -> Result<(), Box<dyn std::error::Error>> {
+pub fn shift_cursor_right_with_deselect(char_count: usize) -> Result<(), Box<dyn std::error::Error>> {
     if char_count == 0 {
         return Ok(());
     }

--- a/native/selected-text-reader/src/macos.rs
+++ b/native/selected-text-reader/src/macos.rs
@@ -175,27 +175,74 @@ pub fn get_cursor_context(context_length: usize) -> Result<String, Box<dyn std::
     // Store original clipboard contents
     let original_clipboard = clipboard.get_text().unwrap_or_default();
 
-    // Clear clipboard before selection
+    // First, get any existing selected text
     clipboard
         .clear()
         .map_err(|e| format!("Clipboard clear failed: {}", e))?;
+    native_cmd_c()?;
+    thread::sleep(Duration::from_millis(25));
+    let selected_text = clipboard.get_text().unwrap_or_default();
+    let selected_char_count = selected_text.chars().count();
 
-    // Select previous context_length characters with Shift+Left and copy
-    let result = select_previous_chars_and_copy(context_length, &mut clipboard);
+    let context_text = if selected_char_count == 0 {
+        // Case 1: No selected text - proceed normally with cursor context
+        clipboard
+            .clear()
+            .map_err(|e| format!("Clipboard clear failed: {}", e))?;
 
-    // Handle the shift right to deselect and restore cursor position
-    let context_text = match &result {
-        Ok(text) => {
-            // Move cursor right by the number of characters we captured to deselect
-            // This prevents paste conflicts in applications that don't allow pasting over selections
-            let max_chars_to_move = text.chars().count();
-            let chars_to_move = std::cmp::min(max_chars_to_move, context_length);
-            if chars_to_move > 0 {
-                let _ = shift_cursor_right_with_deselect(chars_to_move);
+        let result = select_previous_chars_and_copy(context_length, &mut clipboard);
+        match result {
+            Ok(precursor_text) => {
+                let precursor_char_count = precursor_text.chars().count();
+                // Shift right by the amount we grabbed
+                if precursor_char_count > 0 {
+                    let _ = shift_cursor_right_with_deselect(precursor_char_count);
+                }
+                precursor_text
             }
-            text.clone()
+            Err(e) => format!("[ERROR] {}", e),
         }
-        Err(e) => format!("[ERROR] {}", e)
+    } else {
+        // Case 2: Some text already selected - try extending by one character
+        clipboard
+            .clear()
+            .map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
+        let result = select_previous_chars_and_copy(1, &mut clipboard);
+        match result {
+            Ok(extended_text) => {
+                let extended_char_count = extended_text.chars().count();
+
+                if extended_char_count < selected_char_count {
+                    // Selection shrunk - undo and return empty
+                    let _ = shift_cursor_right_with_deselect(1);
+                    String::new()
+                } else if extended_char_count == selected_char_count {
+                    // Selection unchanged - return empty, no need to return cursor
+                    String::new()
+                } else {
+                    // Selection extended successfully - continue extending to get full context_length
+                    clipboard
+                        .clear()
+                        .map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
+                    let full_result = select_previous_chars_and_copy(context_length, &mut clipboard);
+                    match full_result {
+                        Ok(full_context_text) => {
+                            let full_context_char_count = full_context_text.chars().count();
+                            // Undo by the absolute difference between original selected text and total selection
+                            let chars_to_undo = (full_context_char_count as i32 - selected_char_count as i32).abs() as usize;
+                            if chars_to_undo > 0 {
+                                let _ = shift_cursor_right_with_deselect(chars_to_undo);
+                            }
+                            full_context_text
+                        }
+                        Err(e) => format!("[ERROR] {}", e)
+                    }
+                }
+            }
+            Err(e) => format!("[ERROR] {}", e),
+        }
     };
 
     // Always restore original clipboard

--- a/native/selected-text-reader/src/macos.rs
+++ b/native/selected-text-reader/src/macos.rs
@@ -235,7 +235,10 @@ pub fn get_cursor_context(context_length: usize) -> Result<String, Box<dyn std::
                             if chars_to_undo > 0 {
                                 let _ = shift_cursor_right_with_deselect(chars_to_undo);
                             }
-                            full_context_text
+
+                            // Return only the newly added context (first n characters where n is the difference)
+                            let new_context_char_count = full_context_char_count - selected_char_count;
+                            full_context_text.chars().take(new_context_char_count).collect()
                         }
                         Err(e) => format!("[ERROR] {}", e)
                     }

--- a/native/selected-text-reader/src/macos.rs
+++ b/native/selected-text-reader/src/macos.rs
@@ -102,84 +102,13 @@ fn native_cmd_c() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// Native macOS Cmd+X implementation using raw Quartz C API
-fn native_cmd_x() -> Result<(), Box<dyn std::error::Error>> {
-    unsafe {
-        // Key code for 'X' is 7 on macOS
-        let x_key_code: CGKeyCode = 7;
-
-        // Create key down event for Cmd+X
-        let key_down_event = CGEventCreateKeyboardEvent(ptr::null_mut(), x_key_code, true);
-        if key_down_event.is_null() {
-            return Err("Failed to create key down event".into());
-        }
-
-        // Set Command flag
-        CGEventSetFlags(key_down_event, CG_EVENT_FLAG_MASK_COMMAND);
-
-        // Mark this as a synthetic event to help avoid hotkey interference
-        // Using user info field to mark our events (field 121 is a user data field)
-        CGEventSetIntegerValueField(key_down_event, 121, 0x49544F); // 'ITO' in hex
-
-        // Create key up event for Cmd+X
-        let key_up_event = CGEventCreateKeyboardEvent(ptr::null_mut(), x_key_code, false);
-        if key_up_event.is_null() {
-            CFRelease(key_down_event as *const c_void);
-            return Err("Failed to create key up event".into());
-        }
-
-        // Set Command flag
-        CGEventSetFlags(key_up_event, CG_EVENT_FLAG_MASK_COMMAND);
-
-        // Mark this as a synthetic event too
-        CGEventSetIntegerValueField(key_up_event, 121, 0x49544F); // 'ITO' in hex
-
-        // Post the events using session event tap instead of HID event tap
-        // This might make them less visible to the global-key-listener
-        CGEventPost(CG_SESSION_EVENT_TAP, key_down_event);
-        thread::sleep(Duration::from_millis(10));
-        CGEventPost(CG_SESSION_EVENT_TAP, key_up_event);
-
-        // Clean up
-        CFRelease(key_down_event as *const c_void);
-        CFRelease(key_up_event as *const c_void);
-    }
-
-    Ok(())
-}
-
-// Double Cmd+C copy for stubborn Electron apps using native events
-fn double_copy_method(clipboard: &mut Clipboard) -> Result<String, Box<dyn std::error::Error>> {
-    // Clear clipboard to detect if copy operation worked
-    clipboard.clear()?;
-
-    // Perform first Cmd+C
-    native_cmd_c()?;
-
-    // Short delay between copies
-    thread::sleep(Duration::from_millis(25));
-
-    // Perform second Cmd+C
-    native_cmd_c()?;
-
-    // Slightly longer delay for double copy
-    thread::sleep(Duration::from_millis(75));
-
-    // Try to get the copied text
-    match clipboard.get_text() {
-        Ok(text) => Ok(text),
-        Err(_) => Ok(String::new()),
-    }
-}
-
 // Simple function to select previous N characters and copy them
-fn select_previous_chars_and_copy(char_count: usize, clipboard: &mut Clipboard) -> Result<String, Box<dyn std::error::Error>> {
-    // Clear clipboard before selection
-    clipboard.clear().map_err(|e| format!("Clipboard clear failed: {}", e))?;
-
+fn select_previous_chars_and_copy(
+    char_count: usize,
+    clipboard: &mut Clipboard,
+) -> Result<String, Box<dyn std::error::Error>> {
     // Send Shift+Left N times to select precursor text (copied from working get_context)
     for i in 0..char_count {
-
         unsafe {
             let key_down_event = CGEventCreateKeyboardEvent(ptr::null_mut(), 123, true); // Left arrow
             let key_up_event = CGEventCreateKeyboardEvent(ptr::null_mut(), 123, false);
@@ -219,7 +148,6 @@ fn select_previous_chars_and_copy(char_count: usize, clipboard: &mut Clipboard) 
     thread::sleep(Duration::from_millis(10));
 
     native_cmd_c()?;
-    thread::sleep(Duration::from_millis(25)); // Wait for copy to complete (match working timing)
 
     // Adaptively wait for and get text from clipboard
     let mut context_text = String::new();
@@ -236,15 +164,6 @@ fn select_previous_chars_and_copy(char_count: usize, clipboard: &mut Clipboard) 
         }
     }
 
-    // Move cursor right by the number of characters we captured to deselect
-    // This prevents paste conflicts in applications that don't allow pasting over selections
-    let max_chars_to_move = context_text.chars().count();
-    let chars_to_move = std::cmp::min(max_chars_to_move, char_count);
-    if chars_to_move > 0 {
-        shift_cursor_right_with_deselect(chars_to_move)?;
-    }
-
-
     Ok(context_text)
 }
 
@@ -256,17 +175,33 @@ pub fn get_cursor_context(context_length: usize) -> Result<String, Box<dyn std::
     // Store original clipboard contents
     let original_clipboard = clipboard.get_text().unwrap_or_default();
 
+    // Clear clipboard before selection
+    clipboard
+        .clear()
+        .map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
     // Select previous context_length characters with Shift+Left and copy
     let result = select_previous_chars_and_copy(context_length, &mut clipboard);
+
+    // Handle the shift right to deselect and restore cursor position
+    let context_text = match &result {
+        Ok(text) => {
+            // Move cursor right by the number of characters we captured to deselect
+            // This prevents paste conflicts in applications that don't allow pasting over selections
+            let max_chars_to_move = text.chars().count();
+            let chars_to_move = std::cmp::min(max_chars_to_move, context_length);
+            if chars_to_move > 0 {
+                let _ = shift_cursor_right_with_deselect(chars_to_move);
+            }
+            text.clone()
+        }
+        Err(e) => format!("[ERROR] {}", e)
+    };
 
     // Always restore original clipboard
     let _ = clipboard.set_text(original_clipboard);
 
-    // Return debug info if we got nothing
-    match result {
-        Ok(text) => Ok(text),
-        Err(e) => Ok(format!("[ERROR] {}", e)),
-    }
+    Ok(context_text)
 }
 
 // Shift cursor right while deselecting text
@@ -304,59 +239,5 @@ fn shift_cursor_right_with_deselect(char_count: usize) -> Result<(), Box<dyn std
         }
     }
 
-    Ok(())
-}
-
-fn move_cursor_right(char_count: usize) -> Result<(), Box<dyn std::error::Error>> {
-    if char_count == 0 {
-        return Ok(());
-    }
-
-    unsafe {
-        let right_arrow_key_code: CGKeyCode = 124;
-
-        // Move right character by character to restore cursor position
-        // For efficiency, we could batch this but for safety we'll do it simply
-        for _ in 0..char_count {
-            let key_down_event =
-                CGEventCreateKeyboardEvent(ptr::null_mut(), right_arrow_key_code, true);
-            let key_up_event =
-                CGEventCreateKeyboardEvent(ptr::null_mut(), right_arrow_key_code, false);
-
-            if !key_down_event.is_null() && !key_up_event.is_null() {
-                CGEventPost(CG_SESSION_EVENT_TAP, key_down_event);
-                CGEventPost(CG_SESSION_EVENT_TAP, key_up_event);
-
-                CFRelease(key_down_event as *const c_void);
-                CFRelease(key_up_event as *const c_void);
-            }
-
-            // Small delay between movements for very long selections
-            if char_count > 50 && char_count % 10 == 0 {
-                thread::sleep(Duration::from_millis(1));
-            }
-        }
-    }
-
-    Ok(())
-}
-
-// Optimized cursor restoration using single right-arrow press
-fn restore_cursor_position() -> Result<(), Box<dyn std::error::Error>> {
-    unsafe {
-        let right_arrow_key_code: CGKeyCode = 124;
-
-        let key_down = CGEventCreateKeyboardEvent(ptr::null_mut(), right_arrow_key_code, true);
-        let key_up = CGEventCreateKeyboardEvent(ptr::null_mut(), right_arrow_key_code, false);
-
-        if !key_down.is_null() && !key_up.is_null() {
-            CGEventPost(CG_SESSION_EVENT_TAP, key_down);
-            // No need for a delay here, it's a single atomic action
-            CGEventPost(CG_SESSION_EVENT_TAP, key_up);
-
-            CFRelease(key_down as *const c_void);
-            CFRelease(key_up as *const c_void);
-        }
-    }
     Ok(())
 }

--- a/native/selected-text-reader/src/main.rs
+++ b/native/selected-text-reader/src/main.rs
@@ -1,6 +1,8 @@
+use arboard::Clipboard;
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufRead, Write};
 use std::thread;
+use std::time::Duration;
 
 // Platform-specific modules
 #[cfg(any(target_os = "windows", target_os = "linux"))]
@@ -210,12 +212,112 @@ fn get_selected_text() -> Result<String, Box<dyn std::error::Error>> {
     cross_platform::get_selected_text()
 }
 
-#[cfg(target_os = "macos")]
 fn get_cursor_context(context_length: usize) -> Result<String, Box<dyn std::error::Error>> {
-    macos::get_cursor_context(context_length)
+    // Use keyboard commands to get cursor context
+    // This is more reliable across different applications than Accessibility API
+    let mut clipboard = Clipboard::new().map_err(|e| format!("Clipboard init failed: {}", e))?;
+
+    // Store original clipboard contents
+    let original_clipboard = clipboard.get_text().unwrap_or_default();
+
+    // First, get any existing selected text
+    clipboard.clear().map_err(|e| format!("Clipboard clear failed: {}", e))?;
+    copy_selected_text()?;
+    thread::sleep(Duration::from_millis(25));
+    let selected_text = clipboard.get_text().unwrap_or_default();
+    let selected_char_count = selected_text.chars().count();
+
+    let context_text = if selected_char_count == 0 {
+        // Case 1: No selected text - proceed normally with cursor context
+        clipboard.clear().map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
+        let result = select_previous_chars_and_copy(context_length, &mut clipboard);
+        match result {
+            Ok(precursor_text) => {
+                let precursor_char_count = precursor_text.chars().count();
+                // Shift right by the amount we grabbed
+                if precursor_char_count > 0 {
+                    let _ = shift_cursor_right_with_deselect(precursor_char_count);
+                }
+                precursor_text
+            }
+            Err(e) => format!("[ERROR] {}", e)
+        }
+    } else {
+        // Case 2: Some text already selected - try extending by one character
+        clipboard.clear().map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
+        let result = select_previous_chars_and_copy(1, &mut clipboard);
+        match result {
+            Ok(extended_text) => {
+                let extended_char_count = extended_text.chars().count();
+
+                if extended_char_count < selected_char_count {
+                    // Selection shrunk - undo and return empty
+                    let _ = shift_cursor_right_with_deselect(1);
+                    String::new()
+                } else if extended_char_count == selected_char_count {
+                    // Selection unchanged - return empty, no need to return cursor
+                    String::new()
+                } else {
+                    // Selection extended successfully - continue extending to get full context_length
+                    clipboard.clear().map_err(|e| format!("Clipboard clear failed: {}", e))?;
+
+                    let full_result = select_previous_chars_and_copy(context_length, &mut clipboard);
+                    match full_result {
+                        Ok(full_context_text) => {
+                            let full_context_char_count = full_context_text.chars().count();
+                            // Undo by the absolute difference between original selected text and total selection
+                            let chars_to_undo = (full_context_char_count as i32 - selected_char_count as i32).abs() as usize;
+                            if chars_to_undo > 0 {
+                                let _ = shift_cursor_right_with_deselect(chars_to_undo);
+                            }
+
+                            // Return only the newly added context (first n characters where n is the difference)
+                            let new_context_char_count = full_context_char_count - selected_char_count;
+                            full_context_text.chars().take(new_context_char_count).collect()
+                        }
+                        Err(e) => format!("[ERROR] {}", e)
+                    }
+                }
+            }
+            Err(e) => format!("[ERROR] {}", e)
+        }
+    };
+
+    // Always restore original clipboard
+    let _ = clipboard.set_text(original_clipboard);
+
+    Ok(context_text)
+}
+
+// Platform-specific helper functions
+#[cfg(target_os = "macos")]
+fn copy_selected_text() -> Result<(), Box<dyn std::error::Error>> {
+    macos::native_cmd_c()
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
-fn get_cursor_context(context_length: usize) -> Result<String, Box<dyn std::error::Error>> {
-    cross_platform::get_cursor_context(context_length)
+fn copy_selected_text() -> Result<(), Box<dyn std::error::Error>> {
+    cross_platform::copy_selected_text()
+}
+
+#[cfg(target_os = "macos")]
+fn select_previous_chars_and_copy(char_count: usize, clipboard: &mut Clipboard) -> Result<String, Box<dyn std::error::Error>> {
+    macos::select_previous_chars_and_copy(char_count, clipboard)
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+fn select_previous_chars_and_copy(char_count: usize, clipboard: &mut Clipboard) -> Result<String, Box<dyn std::error::Error>> {
+    cross_platform::select_previous_chars_and_copy(char_count, clipboard)
+}
+
+#[cfg(target_os = "macos")]
+fn shift_cursor_right_with_deselect(char_count: usize) -> Result<(), Box<dyn std::error::Error>> {
+    macos::shift_cursor_right_with_deselect(char_count)
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+fn shift_cursor_right_with_deselect(char_count: usize) -> Result<(), Box<dyn std::error::Error>> {
+    cross_platform::shift_cursor_right_with_deselect(char_count)
 }


### PR DESCRIPTION
The grammar service didn't handle all edge cases. It should be a little more conservative now, with a check to be sure it is actually grabbing precursor context and not just reducing the already highlighted text selection.

I also tried to consolidate the logic into the main.rs file and leave the macos/windows rust specific files much more targeted to handling the keyboard commands.