### PR TITLE
ITO-291: fix crlf windows endings for grammar service

### DIFF
--- a/native/selected-text-reader/src/cross_platform.rs
+++ b/native/selected-text-reader/src/cross_platform.rs
@@ -2,6 +2,12 @@ use arboard::Clipboard;
 use std::thread;
 use std::time::Duration;
 
+// Count characters as the editor sees them (CRLF = 1 cursor position on Windows)
+pub fn count_editor_chars(text: &str) -> usize {
+    // On Windows, editors treat CRLF as a single cursor position when navigating with arrow keys
+    text.replace("\r\n", "\n").chars().count()
+}
+
 pub fn get_selected_text() -> Result<String, Box<dyn std::error::Error>> {
     let mut clipboard = Clipboard::new().map_err(|e| format!("Clipboard init failed: {}", e))?;
 

--- a/native/selected-text-reader/src/macos.rs
+++ b/native/selected-text-reader/src/macos.rs
@@ -8,6 +8,11 @@ use std::time::Duration;
 
 static GET_SELECTED_TEXT_METHOD: Mutex<Option<LruCache<String, u8>>> = Mutex::new(None);
 
+// Count characters as the editor sees them (on macOS, just use normal char count)
+pub fn count_editor_chars(text: &str) -> usize {
+    text.chars().count()
+}
+
 // Raw Quartz C API bindings for CGEventCreateKeyboardEvent
 #[repr(C)]
 struct __CGEvent(c_void);


### PR DESCRIPTION
shift + left on windows for a newline will grab the character \r\n, which counts as two characters in a string literal. This PR normalizes carriage return line feeds to count as a single character, as we only need a single keystroke to traverse it.