### PR TITLE
relieve IO pressure on audio recorder, upsample to 48khz to make comm…

### DIFF
--- a/native/audio-recorder/src/main.rs
+++ b/native/audio-recorder/src/main.rs
@@ -79,6 +79,9 @@ struct CommandProcessor {
     active_stream: Option<cpal::Stream>,
     stdout: Arc<Mutex<io::Stdout>>,
     cached_host: Option<Rc<cpal::Host>>,
+    // Offloaded writer thread state
+    audio_tx: Option<crossbeam_channel::Sender<Vec<f32>>>,
+    writer_handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl CommandProcessor {
@@ -88,6 +91,8 @@ impl CommandProcessor {
             active_stream: None,
             stdout,
             cached_host: None,
+            audio_tx: None,
+            writer_handle: None,
         }
     }
 
@@ -155,9 +160,11 @@ impl CommandProcessor {
         self.stop_recording();
 
         let host = self.get_or_create_host();
-        if let Ok(stream) = start_capture(device_name, Arc::clone(&self.stdout), host) {
-            if stream.play().is_ok() {
-                self.active_stream = Some(stream)
+        if let Ok(handles) = start_capture(device_name, Arc::clone(&self.stdout), host) {
+            if handles.stream.play().is_ok() {
+                self.audio_tx = Some(handles.audio_tx);
+                self.writer_handle = Some(handles.writer_handle);
+                self.active_stream = Some(handles.stream);
             }
         } else {
             eprintln!("[audio-recorder] CRITICAL: Failed to create audio stream");
@@ -168,6 +175,13 @@ impl CommandProcessor {
         if let Some(stream) = self.active_stream.take() {
             let _ = stream.pause();
             drop(stream);
+        }
+        // Close audio channel to signal writer thread to exit
+        if let Some(tx) = self.audio_tx.take() {
+            drop(tx);
+        }
+        if let Some(handle) = self.writer_handle.take() {
+            let _ = handle.join();
         }
     }
 
@@ -273,13 +287,117 @@ fn write_audio_chunk(data: &[f32], stdout: &Arc<Mutex<io::Stdout>>) {
     }
 }
 
+struct CaptureHandles {
+    stream: cpal::Stream,
+    audio_tx: crossbeam_channel::Sender<Vec<f32>>,
+    writer_handle: std::thread::JoinHandle<()>,
+}
+
+fn downmix_to_mono_vec<T>(data: &[T], num_channels: usize) -> Vec<f32>
+where
+    T: Sample,
+    f32: FromSample<T>,
+{
+    if num_channels <= 1 {
+        return data.iter().map(|s| s.to_sample::<f32>()).collect();
+    }
+    let mut out: Vec<f32> = Vec::with_capacity(data.len() / num_channels);
+    let mut i = 0;
+    while i + num_channels <= data.len() {
+        let mut sum = 0.0f32;
+        for c in 0..num_channels {
+            sum += data[i + c].to_sample::<f32>();
+        }
+        out.push(sum / (num_channels as f32));
+        i += num_channels;
+    }
+    out
+}
+
+fn writer_loop(
+    audio_rx: crossbeam_channel::Receiver<Vec<f32>>,
+    stdout: Arc<Mutex<io::Stdout>>,
+    input_sample_rate: u32,
+) {
+    const TARGET_SAMPLE_RATE: u32 = 16000;
+    const RESAMPLER_CHUNK_SIZE: usize = 2048; // larger chunk to reduce overhead
+
+    let mut resampler_opt = if input_sample_rate != TARGET_SAMPLE_RATE {
+        match FftFixedIn::new(
+            input_sample_rate as usize,
+            TARGET_SAMPLE_RATE as usize,
+            RESAMPLER_CHUNK_SIZE,
+            1,
+            1,
+        ) {
+            Ok(r) => Some(r),
+            Err(e) => {
+                eprintln!("[audio-recorder] CRITICAL: Failed to create resampler: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let mut in_buffer: Vec<f32> = Vec::new();
+
+    while let Ok(frame) = audio_rx.recv() {
+        if let Some(resampler) = resampler_opt.as_mut() {
+            in_buffer.extend_from_slice(&frame);
+            while in_buffer.len() >= RESAMPLER_CHUNK_SIZE {
+                let chunk_to_process: Vec<f32> = in_buffer
+                    .drain(..RESAMPLER_CHUNK_SIZE)
+                    .collect::<Vec<_>>();
+                match resampler.process(&[chunk_to_process], None) {
+                    Ok(mut resampled) => {
+                        if !resampled.is_empty() {
+                            write_audio_chunk(&resampled.remove(0), &stdout);
+                        }
+                    }
+                    Err(e) => eprintln!(
+                        "[audio-recorder] CRITICAL: Resampling failed in writer: {}",
+                        e
+                    ),
+                }
+            }
+        } else {
+            // direct write at input rate
+            write_audio_chunk(&frame, &stdout);
+        }
+    }
+
+    // Channel closed; flush any remaining buffered samples through resampler
+    if let Some(mut resampler) = resampler_opt.take() {
+        while !in_buffer.is_empty() {
+            let take = if in_buffer.len() >= RESAMPLER_CHUNK_SIZE {
+                RESAMPLER_CHUNK_SIZE
+            } else {
+                in_buffer.len()
+            };
+            let mut chunk = in_buffer.drain(..take).collect::<Vec<_>>();
+            if chunk.len() < RESAMPLER_CHUNK_SIZE {
+                // zero-pad final chunk to meet resampler size
+                chunk.resize(RESAMPLER_CHUNK_SIZE, 0.0);
+            }
+            if let Ok(mut resampled) = resampler.process(&[chunk], None) {
+                if !resampled.is_empty() {
+                    write_audio_chunk(&resampled.remove(0), &stdout);
+                }
+            }
+        }
+    } else if !in_buffer.is_empty() {
+        write_audio_chunk(&in_buffer, &stdout);
+    }
+}
+
 fn start_capture(
     device_name: Option<String>,
     stdout: Arc<Mutex<io::Stdout>>,
     host: Rc<cpal::Host>,
-) -> Result<cpal::Stream> {
+) -> Result<CaptureHandles> {
     const TARGET_SAMPLE_RATE: u32 = 16000;
-    const RESAMPLER_CHUNK_SIZE: usize = 1024;
+    const QUEUE_CAPACITY: usize = 64;
 
     let device = if let Some(name) = device_name {
         if name.to_lowercase() == "default" || name.is_empty() {
@@ -293,33 +411,25 @@ fn start_capture(
     }
     .ok_or_else(|| anyhow!("[audio-recorder] Failed to find input device"))?;
 
-    let config = device
-        .supported_input_configs()?
-        .find(|r| r.channels() > 0)
-        .ok_or_else(|| anyhow!("[audio-recorder] No supported input config found"))?
-        .with_max_sample_rate();
+    // Prefer the device's default input configuration instead of max rate to
+    // better align with other apps (e.g., Zoom) and reduce host resampling.
+    let default_config = device
+        .default_input_config()
+        .map_err(|_| anyhow!("[audio-recorder] No default input config found"))?;
 
-    let input_sample_rate = config.sample_rate().0;
-    let input_sample_format = config.sample_format();
-
-    let mut resampler = if input_sample_rate != TARGET_SAMPLE_RATE {
-        let resampler = FftFixedIn::new(
-            input_sample_rate as usize,
-            TARGET_SAMPLE_RATE as usize,
-            RESAMPLER_CHUNK_SIZE,
-            1,
-            1,
-        )?;
-        Some(resampler)
-    } else {
-        None
-    };
+    let input_sample_rate = default_config.sample_rate().0;
+    let input_sample_format = default_config.sample_format();
+    let channels_count: usize = default_config.channels() as usize;
 
     let err_fn = |err| eprintln!("[audio-recorder] Stream error: {}", err);
-    let stream_config: StreamConfig = config.clone().into();
+    let stream_config: StreamConfig = default_config.clone().into();
 
-    let mut audio_buffer: Vec<f32> = Vec::new();
-    let channels_count: usize = config.channels() as usize;
+    // Writer thread and queue
+    let (audio_tx, audio_rx) = crossbeam_channel::bounded::<Vec<f32>>(QUEUE_CAPACITY);
+    let stdout_for_writer = Arc::clone(&stdout);
+    let writer_handle = std::thread::spawn(move || {
+        writer_loop(audio_rx, stdout_for_writer, input_sample_rate);
+    });
 
     // Notify JS about input and effective output audio configuration
     {
@@ -336,112 +446,90 @@ fn start_capture(
     }
 
     let stream = match input_sample_format {
-        // --- MODIFIED: The callbacks now pass the known chunk size ---
-        SampleFormat::F32 => device.build_input_stream(
-            &stream_config,
-            move |data: &[f32], _| {
-                process_and_write_data(
-                    data,
-                    &mut resampler,
-                    &mut audio_buffer,
-                    &stdout,
-                    RESAMPLER_CHUNK_SIZE,
-                    channels_count,
-                )
-            },
-            err_fn,
-            None,
-        )?,
-        SampleFormat::I16 => device.build_input_stream(
-            &stream_config,
-            move |data: &[i16], _| {
-                process_and_write_data(
-                    data,
-                    &mut resampler,
-                    &mut audio_buffer,
-                    &stdout,
-                    RESAMPLER_CHUNK_SIZE,
-                    channels_count,
-                )
-            },
-            err_fn,
-            None,
-        )?,
-        SampleFormat::U16 => device.build_input_stream(
-            &stream_config,
-            move |data: &[u16], _| {
-                process_and_write_data(
-                    data,
-                    &mut resampler,
-                    &mut audio_buffer,
-                    &stdout,
-                    RESAMPLER_CHUNK_SIZE,
-                    channels_count,
-                )
-            },
-            err_fn,
-            None,
-        )?,
-        SampleFormat::U8 => device.build_input_stream(
-            &stream_config,
-            move |data: &[u8], _| {
-                process_and_write_data(
-                    data,
-                    &mut resampler,
-                    &mut audio_buffer,
-                    &stdout,
-                    RESAMPLER_CHUNK_SIZE,
-                    channels_count,
-                )
-            },
-            err_fn,
-            None,
-        )?,
-        SampleFormat::I32 => device.build_input_stream(
-            &stream_config,
-            move |data: &[i32], _| {
-                process_and_write_data(
-                    data,
-                    &mut resampler,
-                    &mut audio_buffer,
-                    &stdout,
-                    RESAMPLER_CHUNK_SIZE,
-                    channels_count,
-                )
-            },
-            err_fn,
-            None,
-        )?,
-        SampleFormat::F64 => device.build_input_stream(
-            &stream_config,
-            move |data: &[f64], _| {
-                process_and_write_data(
-                    data,
-                    &mut resampler,
-                    &mut audio_buffer,
-                    &stdout,
-                    RESAMPLER_CHUNK_SIZE,
-                    channels_count,
-                )
-            },
-            err_fn,
-            None,
-        )?,
-        SampleFormat::U32 => device.build_input_stream(
-            &stream_config,
-            move |data: &[u32], _| {
-                process_and_write_data(
-                    data,
-                    &mut resampler,
-                    &mut audio_buffer,
-                    &stdout,
-                    RESAMPLER_CHUNK_SIZE,
-                    channels_count,
-                )
-            },
-            err_fn,
-            None,
-        )?,
+        SampleFormat::F32 => {
+            let tx = audio_tx.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[f32], _| {
+                    let mono = downmix_to_mono_vec(data, channels_count);
+                    let _ = tx.try_send(mono);
+                },
+                err_fn,
+                None,
+            )?
+        }
+        SampleFormat::I16 => {
+            let tx = audio_tx.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[i16], _| {
+                    let mono = downmix_to_mono_vec(data, channels_count);
+                    let _ = tx.try_send(mono);
+                },
+                err_fn,
+                None,
+            )?
+        }
+        SampleFormat::U16 => {
+            let tx = audio_tx.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[u16], _| {
+                    let mono = downmix_to_mono_vec(data, channels_count);
+                    let _ = tx.try_send(mono);
+                },
+                err_fn,
+                None,
+            )?
+        }
+        SampleFormat::U8 => {
+            let tx = audio_tx.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[u8], _| {
+                    let mono = downmix_to_mono_vec(data, channels_count);
+                    let _ = tx.try_send(mono);
+                },
+                err_fn,
+                None,
+            )?
+        }
+        SampleFormat::I32 => {
+            let tx = audio_tx.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[i32], _| {
+                    let mono = downmix_to_mono_vec(data, channels_count);
+                    let _ = tx.try_send(mono);
+                },
+                err_fn,
+                None,
+            )?
+        }
+        SampleFormat::F64 => {
+            let tx = audio_tx.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[f64], _| {
+                    let mono = downmix_to_mono_vec(data, channels_count);
+                    let _ = tx.try_send(mono);
+                },
+                err_fn,
+                None,
+            )?
+        }
+        SampleFormat::U32 => {
+            let tx = audio_tx.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[u32], _| {
+                    let mono = downmix_to_mono_vec(data, channels_count);
+                    let _ = tx.try_send(mono);
+                },
+                err_fn,
+                None,
+            )?
+        }
         format => {
             return Err(anyhow!(
                 "[audio-recorder] Unsupported sample format {}",
@@ -450,5 +538,5 @@ fn start_capture(
         }
     };
 
-    Ok(stream)
+    Ok(CaptureHandles { stream, audio_tx, writer_handle })
 }


### PR DESCRIPTION
… routing sound cleaner

Added createStereo48kWavFromMonoPCM to upsample mono 16 kHz PCM to 48 kHz stereo and wrap as WAV.
Switched playback to use the 48 kHz stereo WAV instead of the previous 16 kHz mono WAV for more stable output during calls

Use the device’s default input configuration instead of with_max_sample_rate() to align with system/Zoom settings.
Moved resampling and stdout writes off the real-time audio callback into a dedicated writer thread.
Audio callback now only downmixes to mono and enqueues frames via a bounded channel, avoiding blocking I/O.
Increased resampler chunk size (2048) to reduce per-second work and flush frequency.