### PR TITLE
ITO-336: Long Delay When Using Ito Back to Back

### DIFF
--- a/lib/media/keyboard.ts
+++ b/lib/media/keyboard.ts
@@ -6,7 +6,6 @@ import { BrowserWindow } from 'electron'
 import { audioRecorderService } from './audio'
 import { voiceInputService } from '../main/voiceInputService'
 import { KeyName, keyNameMap, normalizeLegacyKey } from '../types/keyboard'
-import { getProgrammaticTyping } from './typingState'
 import { interactionManager } from '../main/interactions/InteractionManager'
 
 interface KeyEvent {
@@ -188,12 +187,6 @@ function stopStuckKeyChecker() {
 }
 
 function handleKeyEventInMain(event: KeyEvent) {
-  // Ignore keydown-driven hotkey detection while programmatic typing/pasting is in progress,
-  // but still process keyup to clear state and avoid stuck keys.
-  if (getProgrammaticTyping() === true && event.type === 'keydown') {
-    return
-  }
-
   const { isShortcutGloballyEnabled, keyboardShortcuts } = store.get(
     STORE_KEYS.SETTINGS,
   )

--- a/lib/media/text-writer.ts
+++ b/lib/media/text-writer.ts
@@ -1,7 +1,6 @@
 import { execFile } from 'child_process'
 import { platform, arch } from 'os'
 import { getNativeBinaryPath } from './native-interface'
-import { setProgrammaticTyping } from './typingState'
 
 interface TextWriterOptions {
   delay: number // Delay before typing (milliseconds)
@@ -15,14 +14,11 @@ export function setFocusedText(
   options: TextWriterOptions = { delay: 0, charDelay: 0 },
 ): Promise<boolean> {
   return new Promise(resolve => {
-    // Signal to the rest of the app that programmatic typing is active
-    setProgrammaticTyping(true)
     const binaryPath = getNativeBinaryPath(nativeModuleName)
     if (!binaryPath) {
       console.error(
         `Cannot determine ${nativeModuleName} binary path for platform ${platform()} and arch ${arch()}`,
       )
-      setProgrammaticTyping(false)
       return resolve(false)
     }
 
@@ -42,10 +38,8 @@ export function setFocusedText(
     execFile(binaryPath, args, (err, _stdout, stderr) => {
       if (err) {
         console.error('text-writer error:', stderr)
-        setProgrammaticTyping(false)
         return resolve(false)
       }
-      setProgrammaticTyping(false)
       resolve(true)
     })
   })

--- a/lib/media/typingState.ts
+++ b/lib/media/typingState.ts
@@ -1,9 +1,0 @@
-let isProgrammaticTyping = false
-
-export function setProgrammaticTyping(val: boolean) {
-  isProgrammaticTyping = val
-}
-
-export function getProgrammaticTyping() {
-  return isProgrammaticTyping
-}


### PR DESCRIPTION
Now that we're sending synthetic keyboard events for both mac and windows, this should not be necessary. I tested on mac and windows and had no problem with dictation mode.