### PR TITLE
Fix dup analytics events and add cross-platform linking

### DIFF
--- a/lib/preload/api.ts
+++ b/lib/preload/api.ts
@@ -148,6 +148,8 @@ const api = {
   // Analytics device ID methods
   'analytics:get-device-id': () =>
     ipcRenderer.invoke('analytics:get-device-id'),
+  'analytics:resolve-install-token': () =>
+    ipcRenderer.invoke('analytics:resolve-install-token'),
 
   // Onboarding state for current user
   getOnboardingState: () => ipcRenderer.invoke('get-onboarding-state'),

--- a/lib/preload/index.d.ts
+++ b/lib/preload/index.d.ts
@@ -101,6 +101,12 @@ declare global {
 
       // Analytics device ID methods
       'analytics:get-device-id': () => Promise<string | undefined>
+      'analytics:resolve-install-token': () => Promise<{
+        success: boolean
+        websiteDistinctId?: string | null
+        error?: string
+        status?: number
+      }>
 
       notifyLoginSuccess: (
         profile: any,

--- a/lib/window/ipcEvents.ts
+++ b/lib/window/ipcEvents.ts
@@ -663,6 +663,30 @@ export function registerIPC() {
       }
     }
   })
+
+  // Resolve and clear install link token
+  handleIPC('analytics:resolve-install-token', async () => {
+    try {
+      const url = new URL(`/link/resolve`, import.meta.env.VITE_GRPC_BASE_URL)
+      const res = await fetch(url.toString(), {
+        headers: { 'content-type': 'application/json' },
+      })
+      const data: any = await res.json().catch(() => undefined)
+      if (!res.ok) {
+        return {
+          success: false,
+          error: data?.error || `Resolve failed (${res.status})`,
+          status: res.status,
+        }
+      }
+      return {
+        success: true,
+        websiteDistinctId: data?.websiteDistinctId || null,
+      }
+    } catch (error: any) {
+      return { success: false, error: error?.message || 'Unknown error' }
+    }
+  })
 }
 
 // Handlers that are specific to a given window instance

--- a/server/.env.example
+++ b/server/.env.example
@@ -6,6 +6,7 @@ DB_USER=devuser
 DB_PASS=devpass
 DB_NAME=devdb
 DATABASE_URL=postgres://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/${DB_NAME}
+IP_SALT=random_value
 REQUIRE_AUTH=false
 AUTH0_DOMAIN="auth0_domain"
 AUTH0_AUDIENCE="auth0_audience"

--- a/server/src/migrations/1760496947939_add-temporary-analytics-token.js
+++ b/server/src/migrations/1760496947939_add-temporary-analytics-token.js
@@ -1,0 +1,31 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+export const up = pgm => {
+  // IP correlation candidates (privacy: store only hashed IP)
+  pgm.createTable('ip_link_candidates', {
+    ip_hash: { type: 'text', notNull: true },
+    website_distinct_id: { type: 'text', notNull: true },
+    expires_at: { type: 'timestamptz', notNull: true },
+  })
+  pgm.createIndex('ip_link_candidates', ['ip_hash', 'expires_at'], {
+    ifNotExists: true,
+    name: 'ip_link_candidates_ip_exp_idx',
+  })
+}
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+export const down = pgm => {
+  pgm.dropTable('ip_link_candidates', { ifExists: true })
+}


### PR DESCRIPTION
I tried a few different approaches to linking web clicks to and settled on ip linking. It's not perfect but it should match decently well enough.

Other approaches:
1. dmg/exe renaming to include a token ie Ito_some_token.dmg. This would significantly change our infra and lead to a confusing user experience. And I think this breaks auto-updates.
2. com.apple.metadata:kMDItemWhereFroms. This data isn't propagated from the dmg to the Ito.app once it's installed. The problem is then we have to go through the downloads folder to extract it. This feels pretty invasive and leads to issues if there's multiple downloads of the app.
3. ip tracking. This is what I settled on. It's not precise and potentially could be problematic for different users who for some reason use the same ip like a vpn.

I settled on 3 because 1 & 2 have the highest risk of breaking the build and delaying the windows release. I think this should be sufficient.

Along with this pr there's also a web flow script. I don't think I should check it in to this repo.