### PR TITLE
Updating dev build name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,9 +64,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: ./build-app.sh mac
 
-      - name: Compute DMG name
-        run: echo "DMG_NAME=Ito-${{ github.event.release.target_commitish == 'main' && 'Installer' || 'Installer-dev' }}.dmg" >> $GITHUB_ENV
-
       - name: Upload Mac Installer DMG
         uses: actions/upload-artifact@v4
         with:

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -22,7 +22,7 @@ const getWindowsResources = () =>
 const stage = process.env.ITO_ENV || 'prod'
 module.exports = {
   appId: stage === 'prod' ? 'ai.ito.ito' : `ai.ito.ito-${stage.toLowerCase()}`,
-  productName: stage === 'prod' ? 'Ito' : `Ito (${stage})`,
+  productName: stage === 'prod' ? 'Ito' : `Ito-${stage}`,
   copyright: 'Copyright © 2025 Demox Labs',
   directories: {
     buildResources: 'resources',


### PR DESCRIPTION
Removing the space from the product name for Ito dev build. It was causing a subtle error in the build.yml wherein, due to the space, the shell script would parse versioned zip and binary files as two separate files i.e. instead of Ito-dev-1.0.zip it would be Ito and dev-1.0.zip as two separate non existent files that got silently omitted from upload. Joining via hyphen should fix this 