### PR TITLE
Update self-hosted documentation link

### DIFF
--- a/app/components/welcome/contents/CreateAccountContent.tsx
+++ b/app/components/welcome/contents/CreateAccountContent.tsx
@@ -365,7 +365,7 @@ export default function CreateAccountContent() {
                   className="h-10 flex-1 basis-1/2 justify-center rounded border border-black text-base font-medium text-black"
                 >
                   <a
-                    href={EXTERNAL_LINKS.WEBSITE}
+                    href={EXTERNAL_LINKS.SELF_HOSTED_DOCS}
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/lib/constants/external-links.ts
+++ b/lib/constants/external-links.ts
@@ -5,4 +5,6 @@ export const EXTERNAL_LINKS = {
   GITHUB: 'https://github.com/heyito/ito',
   WEBSITE: 'https://www.heyito.ai/',
   PRIVACY_POLICY: 'https://www.heyito.ai/privacy',
+  SELF_HOSTED_DOCS:
+    'https://ito.ai/post/how-to-set-up-your-local-ito-ai-server-on-macos-8nxz5',
 } as const


### PR DESCRIPTION
## Summary
- Updated self-hosted modal documentation link to point to the macOS setup guide
- Added new SELF_HOSTED_DOCS constant to external links

## Changes
- Modified CreateAccountContent.tsx to use the new setup guide link
- Added SELF_HOSTED_DOCS link in external-links.ts pointing to https://ito.ai/post/how-to-set-up-your-local-ito-ai-server-on-macos-8nxz5