### PR TITLE
Change channel logic for auto updater

### DIFF
--- a/lib/main/autoUpdaterWrapper.ts
+++ b/lib/main/autoUpdaterWrapper.ts
@@ -47,13 +47,11 @@ export function initializeAutoUpdater() {
         autoUpdater.forceDevUpdateConfig = true
       }
 
-      const channel = ITO_ENV === 'prod' ? 'latest' : ITO_ENV
       autoUpdater.setFeedURL({
         provider: 's3',
         bucket,
         path: 'releases/',
         region: 'us-west-2',
-        channel,
       })
 
       log.transports.file.level = 'debug'


### PR DESCRIPTION
https://www.electron.build/tutorials/release-using-channels --- we use the latest channel by default for our naming schema i.e. `latest-mac.yml` for dev and prod. Not sure why we needed this change for dev in the first place. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the auto-update feed URL configuration to streamline the update delivery process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->